### PR TITLE
Fix Earthly target that formats TOML files

### DIFF
--- a/.earthly/toml/Earthfile
+++ b/.earthly/toml/Earthfile
@@ -1,12 +1,19 @@
 VERSION 0.8
 
+taplo:
+    FROM tamasfe/taplo:latest
+    SAVE ARTIFACT /taplo
+
 FORMAT:
     FUNCTION
 
     ARG FIX="false"
 
-    FROM tamasfe/taplo:latest
+    FROM alpine:latest
     WORKDIR /stone
+
+    # Copy the taplo binary into the container
+    COPY +taplo/taplo /usr/local/bin/taplo
 
     # Copy the source code into the container
     COPY . .


### PR DESCRIPTION
taplo now ships in a distroless Docker container without a shell, which causes issues with Earthly. Instead of running in the taplo container itself, we are now copying the binary into another container and use it there.