### PR TITLE
Collect commands using a build script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,10 @@ name = "clawless-cli"
 version = "0.0.0"
 dependencies = [
  "clap",
+ "convert_case",
  "getset",
+ "proc-macro2",
+ "quote",
  "tokio",
  "trycmd",
 ]
@@ -168,6 +171,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -681,6 +693,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "utf8parse"

--- a/crates/clawless-cli/Cargo.toml
+++ b/crates/clawless-cli/Cargo.toml
@@ -19,3 +19,8 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 trycmd = "0.15.9"
+
+[build-dependencies]
+convert_case = "0.8.0"
+proc-macro2 = "1.0.95"
+quote = "1.0.40"

--- a/crates/clawless-cli/build.rs
+++ b/crates/clawless-cli/build.rs
@@ -1,0 +1,69 @@
+use std::fs::{read_dir, write};
+use std::path::Path;
+
+use convert_case::{Case, Casing};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+fn main() {
+    let crate_root = std::env::var("CARGO_MANIFEST_DIR")
+        .expect("failed to read environment variable CARGO_MANIFEST_DIR");
+    let crate_root_path = Path::new(&crate_root);
+
+    let commands_module = crate_root_path.join("src").join("commands");
+
+    // Collect the commands by scanning the commands directory
+    let commands = collect_commands(&commands_module);
+
+    // Generate the enum
+    let output = generate_commands_enum(&commands);
+
+    // Write to a generated file in Cargo's output directory
+    let out_dir = std::env::var("OUT_DIR").expect("failed to read environment variable OUT_DIR");
+    let out_dir_path = Path::new(&out_dir).join("commands.rs");
+    write(out_dir_path, output).unwrap();
+}
+
+fn collect_commands(dir: &Path) -> Vec<String> {
+    let mut commands = Vec::new();
+
+    for entry in read_dir(dir).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+
+        if path.is_file() && path.extension().is_some_and(|ext| ext == "rs") {
+            // Skip mod.rs
+            if path.file_stem().unwrap() == "mod" {
+                continue;
+            }
+
+            // Add the command name
+            commands.push(path.file_stem().unwrap().to_string_lossy().to_string());
+        }
+    }
+
+    commands
+}
+
+fn generate_commands_enum(commands: &[String]) -> String {
+    let variants = commands.iter().map(|cmd| {
+        let pascal_case = cmd.to_case(Case::Pascal);
+
+        let module: TokenStream = format!("crate::commands::{cmd}").parse().unwrap();
+        let variant = format_ident!("{}", pascal_case);
+        let args = format_ident!("{}Args", pascal_case);
+
+        quote! {
+            #variant(#module::#args)
+        }
+    });
+
+    let tokens = quote! {
+        #[derive(Debug, clap::Subcommand)]
+        pub enum Commands {
+            #(#variants,)*
+        }
+    };
+
+    tokens.to_string()
+}

--- a/crates/clawless-cli/src/app.rs
+++ b/crates/clawless-cli/src/app.rs
@@ -1,16 +1,12 @@
-use clap::{command, Parser, Subcommand};
+use clap::{command, Parser};
 use getset::Getters;
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Parser, Getters)]
+use crate::commands::Commands;
+
+#[derive(Debug, Parser, Getters)]
 #[command(version)]
 pub struct App {
     #[command(subcommand)]
     #[getset(get = "pub")]
     pub command: Commands,
-}
-
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Subcommand)]
-pub enum Commands {
-    /// Create a new CLI with Clawless
-    New { name: String },
 }

--- a/crates/clawless-cli/src/commands.rs
+++ b/crates/clawless-cli/src/commands.rs
@@ -1,0 +1,3 @@
+pub mod new;
+
+include!(concat!(env!("OUT_DIR"), "/commands.rs"));

--- a/crates/clawless-cli/src/commands/new.rs
+++ b/crates/clawless-cli/src/commands/new.rs
@@ -1,0 +1,13 @@
+use clap::Args;
+use getset::Getters;
+
+#[derive(Debug, Args, Getters)]
+pub struct NewArgs {
+    #[arg(index = 1)]
+    #[getset(get = "pub")]
+    name: String,
+}
+
+pub async fn run(args: &NewArgs) {
+    println!("Creating new CLI with name: {}", args.name());
+}

--- a/crates/clawless-cli/src/main.rs
+++ b/crates/clawless-cli/src/main.rs
@@ -1,16 +1,18 @@
 use clap::Parser;
 
-use crate::app::{App, Commands};
+use crate::app::App;
+use crate::commands::Commands;
 
 mod app;
+mod commands;
 
 #[tokio::main]
 async fn main() {
     let app = App::parse();
 
     match app.command {
-        Commands::New { name } => {
-            println!("Creating new CLI with name: {}", name);
+        Commands::New(args) => {
+            crate::commands::new::run(&args).await;
         }
     }
 }


### PR DESCRIPTION
The goal with clawless is to hide most of the complexity of building a command-line interface and allow users to focus on their commands. A first idea that we're exploring is to use a build script to collect the user's commands at build time and inject them into an application that is generated using proc-macros.

This first spike adds a proof-of-concept for a build script that collects a flat list of commands, converts them into an `enum`, and includes that in the application.