### PR TITLE
Call `commands!` macro inside `clawless!` macro

### DIFF
--- a/crates/clawless-cli/src/commands.rs
+++ b/crates/clawless-cli/src/commands.rs
@@ -1,5 +1,1 @@
-use clawless::commands;
-
 pub mod new;
-
-commands!();

--- a/crates/clawless-cli/src/main.rs
+++ b/crates/clawless-cli/src/main.rs
@@ -1,7 +1,5 @@
 use clawless::clawless;
 
-use crate::commands::Commands;
-
 mod commands;
 
-clawless!(Commands);
+clawless!();

--- a/crates/clawless/src/lib.rs
+++ b/crates/clawless/src/lib.rs
@@ -24,14 +24,16 @@ where
 #[macro_export]
 macro_rules! clawless {
     // Accept a single argument, which is the enum of commands
-    ($commands:ident) => {
+    () => {
+        $crate::commands!();
+
         fn main() {
             use clap::Parser;
-            let app = $crate::App::<$commands>::parse();
+            let app = $crate::App::parse();
 
             $crate::run_async(async {
                 match app.command {
-                    $commands::New(args) => {
+                    Commands::New(args) => {
                         commands::new::run(&args).await;
                     }
                 }


### PR DESCRIPTION
The `commands!` macro that includes the `Commands` enum is now called inside the `clawless!` macro, effectively hiding the enum as an implementation detail from the user. This further cleans up the public interface of clawless.