### PR TITLE
Document the crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # 🦦 Clawless
 
-`clawless` is a framework for building command-line applications with Rust.
+Clawless is a framework for building command-line applications with Rust. Its
+goal is to provide high-level building blocks and well-designed conventions so
+that users can focus on their applications.
+
+Check out the [`clawless`](./crates/clawless/) crate to learn more about using
+the framework for your own projects.
+
+## Project Status
+
+Clawless is in a very early prototyping phase and not considered ready for
+production use. Follow the project and check out its open issues to understand
+the frameworks's current limitations and future roadmap.
 
 ## License
 

--- a/crates/clawless-derive/README.md
+++ b/crates/clawless-derive/README.md
@@ -1,0 +1,29 @@
+# 🦦 `clawless-derive`
+
+`clawless` is a framework for building command-line applications with Rust, and
+the `clawless-derive` crate implements the procedural macros that power this
+framework.
+
+The crate defines the `app!` macro and the `#[command]` macro attribute, which
+the `clawless` crate re-exports. The `app!` macro generates a noop `#[command]`
+as the root of the command-line application, while the `#[command]` macro
+attribute does the heavy lifting of creating a command and registering it with
+its parent.
+
+Check the documentation of the two macros to get a better understanding of how
+this crate works.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 (<http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license (<http://opensource.org/licenses/MIT>)
+
+at your option.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.

--- a/crates/clawless-derive/src/lib.rs
+++ b/crates/clawless-derive/src/lib.rs
@@ -1,3 +1,6 @@
+#![cfg_attr(not(doctest),doc = include_str!("../README.md"))]
+#![warn(missing_docs)]
+
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, ItemFn};
@@ -10,12 +13,52 @@ mod app;
 mod command;
 mod inventory;
 
+/// Generate a Clawless application
+///
+/// This macro generates an empty Clawless application that can be extended with
+/// subcommands. It is supposed to be called in a module called `commands`,
+/// with commands defined in submodules.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// mod commands {
+///     clawless::app!();
+/// }
+/// ```
 #[proc_macro]
 pub fn app(_input: TokenStream) -> TokenStream {
     let app_generator = AppGenerator::new();
     app_generator.app_function().into()
 }
 
+/// Add a command to a Clawless application
+///
+/// This macro attribute can be used to register a function as a (sub)command in
+/// Clawless application. The name of the function will be used as the name of
+/// the command, and it will be automatically registered as a subcommand under
+/// its parent module.
+///
+/// Command functions expect a single argument, which is a `clap::Args` struct
+/// with arguments that will be passed to the command.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use clap::Args;
+/// use clawless::command;
+///
+/// #[derive(Debug, Args)]
+/// pub struct CommandArgs {
+///     #[arg(short, long)]
+///     name: String,
+/// }
+///
+/// #[command]
+/// pub async fn command(args: CommandArgs) {
+///     println!("Running a command: {}", args.name);
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn command(attrs: TokenStream, input: TokenStream) -> TokenStream {
     let input_function = parse_macro_input!(input as ItemFn);

--- a/crates/clawless/README.md
+++ b/crates/clawless/README.md
@@ -1,0 +1,86 @@
+# 🦦 Clawless
+
+`clawless` is a framework for building command-line applications with Rust. Its
+goal is to provide high-level building blocks and well-designed conventions so
+that users can focus on their applications.
+
+The library exports a few macros that create a command-line application, parse
+arguments, and then call user-defined functions.
+
+## Project Status
+
+Clawless is in a very early prototyping phase and not considered ready for
+production use. Follow the project and check out the open issues to understand
+the crate's current limitations.
+
+## Usage
+
+First of all, generate a new binary crate using `cargo new --bin <name>`. Inside
+the crate, open `src/main.rs` and replace the generated contents with the
+following snippet:
+
+```rust,ignore
+use clawless::clawless;
+
+mod commands;
+
+fn main() {
+    clawless!()
+}
+```
+
+Go ahead and create the `src/commands.rs` module, and add the following line to
+set up the Clawless application:
+
+```rust
+clawless::app!();
+```
+
+You can now start adding commands to the application by creating submodules in
+`commands`, adding a function, and tagging it as a command.
+
+First, register a new submodule in `src/commands.rs`:
+
+```rust
+pub mod command;
+```
+
+Create `src/commands/command.rs`, and then add a struct and a function to the
+file:
+
+```rust
+use clap::Args;
+use clawless::command;
+
+#[derive(Debug, Args)]
+pub struct CommandArgs {
+    #[arg(short, long)]
+    name: String,
+}
+
+#[command]
+pub async fn command(args: CommandArgs) {
+    println!("Running a command: {}", args.name);
+}
+```
+
+You can execute the command by calling your command-line application:
+
+```shell
+cargo run -- command
+```
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 (<http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license (<http://opensource.org/licenses/MIT>)
+
+at your option.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.

--- a/crates/clawless/src/lib.rs
+++ b/crates/clawless/src/lib.rs
@@ -1,10 +1,18 @@
+#![cfg_attr(not(doctest),doc = include_str!("../README.md"))]
+#![warn(missing_docs)]
+
 pub use clawless_derive::{app, command};
 
 // Re-export the inventory crate for use with the `clawless-derive` crate
 #[doc(hidden)]
 pub use inventory;
 
-/// Run an async function in the Clawless runtime
+/// Run an async function in an async runtime.
+///
+/// This function starts an asynchronous runtime and blocks until the passed
+/// future is resolved. It is used internally by the `clawless!` macro to hide
+/// the use of the `tokio` runtime as an implementation detail.
+#[doc(hidden)]
 pub fn run_async<F>(future: F)
 where
     F: std::future::Future<Output = ()>,
@@ -13,8 +21,27 @@ where
     rt.block_on(future);
 }
 
+/// Initialize and run a Clawless application
+///
+/// This macro initializes a Clawless application and runs it in an asynchronous
+/// runtime. It requires that the `app!` macro has been called in a submodule
+/// called `commands` to initialize the application and that at least one
+/// `#[command]` has been registered.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use clawless::clawless;
+///
+/// mod commands;
+///
+/// fn main() {
+///     clawless!()
+/// }
+/// ```
 #[macro_export]
 #[allow(clippy::crate_in_macro_def)] // The use of `crate` is intentional
+#[allow(clippy::needless_doctest_main)]
 macro_rules! clawless {
     () => {
         $crate::run_async(async {


### PR DESCRIPTION
The `clawless` and `clawless-derive` crates have been documented, and clippy has been configured to require documentation for all public items from now on.