### PR TITLE
Check GitHub Actions using zizmor

### DIFF
--- a/.earthly/github/Earthfile
+++ b/.earthly/github/Earthfile
@@ -1,0 +1,13 @@
+VERSION 0.8
+
+LINT:
+    FUNCTION
+
+    FROM ghcr.io/zizmorcore/zizmor:1.9.0
+    WORKDIR /clawless
+
+    # Copy the source code into the container
+    COPY --dir .github .
+
+    # Run static analysis on the GitHub Actions workflows
+    RUN zizmor ./

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,20 @@ jobs:
     name: Enumerate Earthly targets
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     outputs:
       matrix: ${{ steps.export-targets.outputs.targets }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+        with:
+          persist-credentials: false
 
       - name: Install earthly
-        uses: jdno/earthly-actions-setup@v2.0.0
+        uses: jdno/earthly-actions-setup@151d424aaf3ae0ad63c069c0ef51f5dd65c96e76 # 2.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: 0.8
@@ -44,31 +49,37 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+        with:
+          persist-credentials: false
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # 3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install earthly
-        uses: jdno/earthly-actions-setup@v2.0.0
+        uses: jdno/earthly-actions-setup@151d424aaf3ae0ad63c069c0ef51f5dd65c96e76 # 2.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: 0.8
 
       - name: Run check with Earthly
+        # zizmor: ignore[template-injection]
         run: earthly --allow-privileged --ci --push --remote-cache=ghcr.io/jdno/clawless-earthly-cache:${{ matrix.target }} +${{ matrix.target }}
 
   success:
     name: All checks succeeded
     runs-on: ubuntu-latest
 
+    permissions: {}
+
     needs: checks
     if: always()
 
     steps:
       - name: Check if all checks succeeded
+        # zizmor: ignore[template-injection]
         run: jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -22,17 +22,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+        with:
+          persist-credentials: false
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # 3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install earthly
-        uses: jdno/earthly-actions-setup@v2.0.0
+        uses: jdno/earthly-actions-setup@151d424aaf3ae0ad63c069c0ef51f5dd65c96e76 # 2.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: 0.8

--- a/Earthfile
+++ b/Earthfile
@@ -15,6 +15,7 @@ checks:
     BUILD +format-rust --FIX="false"
     BUILD +format-toml --FIX="false"
     BUILD +format-yaml --FIX="false"
+    BUILD +lint-github-actions
     BUILD +lint-markdown
     BUILD +lint-rust
     BUILD +lint-yaml
@@ -30,6 +31,7 @@ pre-commit:
         BUILD +format-toml
     END
     BUILD +format-rust
+    BUILD +lint-github-actions
     BUILD +lint-markdown
     BUILD +lint-rust
     BUILD +lint-yaml
@@ -69,6 +71,9 @@ format-toml:
 format-yaml:
     ARG FIX="false"
     DO ./.earthly/prettier+PRETTIER --EXTENSION="{yaml,yml}" --FIX="$FIX"
+
+lint-github-actions:
+    DO ./.earthly/github+LINT
 
 lint-markdown:
     DO ./.earthly/markdown+LINT


### PR DESCRIPTION
zizmor[^1] has been added as a check to the continuous integration setup of this project. It is run both as a pre-commit hook and a job on GitHub Actions to ensure we are following the best practices for GitHub Actions and avoid potentially dangerous configurations.

zizmor warns that the use of `${{ matrix.target }}` statements enables possible template injections, since it cannot statically check the inputs to the statement. Since they are coming from the `earthly ls` command and are further filtered by `jq`, we deem the risk of template injection to be very low.

[^1]: https://zizmor.sh/