### PR TITLE
Prepare repository for automated releases

### DIFF
--- a/.earthly/rust/Earthfile
+++ b/.earthly/rust/Earthfile
@@ -113,10 +113,13 @@ MSRV:
 PUBLISH:
     FUNCTION
 
+    # Pass the name of the crate to publish
+    ARG CRATE
+
     DO +SOURCES
 
     # Publish the crate to crates.io
-    DO rust+CARGO --secret CARGO_REGISTRY_TOKEN --args="cargo publish -v --all-features --token $CARGO_REGISTRY_TOKEN"
+    RUN --secret CARGO_REGISTRY_TOKEN cargo publish -p $CRATE -v --all-features --token $CARGO_REGISTRY_TOKEN
 
 SOURCES:
     FUNCTION

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,46 @@
+---
+- name: C-bug
+  color: e74c3c
+  description: "Report a new bug"
+- name: C-dependency
+  color: e74c3c
+  description: "Change or update a dependency"
+- name: C-documentation
+  color: e74c3c
+  description: "Improve the documentation"
+- name: C-feature-request
+  color: e74c3c
+  description: "Request a new feature"
+- name: L-github
+  color: 34495e
+  description: "Tag the GitHub ecosystem"
+- name: L-rust
+  color: 34495e
+  description: "Tag the Rust ecosystem"
+- name: PR-block
+  color: 3498db
+  description: "Do not merge the pull request"
+- name: PR-merge
+  color: 3498db
+  description: "Merge pull request when checks passed"
+- name: R-added
+  color: 95a5a6
+  description: "Add a new feature to the release notes"
+- name: R-changed
+  color: 95a5a6
+  description: "Add a change in existing functionality to the release notes"
+- name: R-deprecated
+  color: 95a5a6
+  description: "Add a soon-to-be removed feature to the release notes"
+- name: R-fixed
+  color: 95a5a6
+  description: "Add a fixed bug to the release notes"
+- name: R-ignore
+  color: 95a5a6
+  description: "Do not add this pull request to the release notes"
+- name: R-removed
+  color: 95a5a6
+  description: "Add a now removed feature to the release notes"
+- name: R-security
+  color: 95a5a6
+  description: "Add a vulnerability warning to the release notes"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+---
+changelog:
+  exclude:
+    labels:
+      - R-ignore
+  categories:
+    - title: Security
+      labels:
+        - R-security
+    - title: Added
+      labels:
+        - R-added
+    - title: Changed
+      labels:
+        - R-changed
+    - title: Deprecated
+      labels:
+        - R-deprecated
+    - title: Removed
+      labels:
+        - R-removed
+    - title: Fixed
+      labels:
+        - R-fixed

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -1,0 +1,30 @@
+---
+name: GitHub
+
+"on":
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  labels:
+    name: Sync labels
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Sync labels
+        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # 1.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manifest: .github/labels.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+---
+name: Release
+
+"on":
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # 3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install earthly
+        uses: jdno/earthly-actions-setup@151d424aaf3ae0ad63c069c0ef51f5dd65c96e76 # 2.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 0.8
+
+      - name: Publish with Earthly
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
+        run: earthly --ci --push --remote-cache=ghcr.io/jdno/clawless-earthly-cache:publish-crates --secret CARGO_REGISTRY_TOKEN  +publish-crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,6 @@ rust-version = "1.78.0"
 
 [workspace.dependencies]
 clap = { version = "4.1", features = ["derive"] }
-clawless = { path = "crates/clawless" }
-clawless-cli = { path = "crates/clawless-cli" }
-clawless-derive = { path = "crates/clawless-derive" }
 inventory = "0.3"
 getset = "0.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/Earthfile
+++ b/Earthfile
@@ -88,8 +88,9 @@ prettier:
     ARG FIX="false"
     DO ./.earthly/prettier+PRETTIER --FIX="$FIX"
 
-publish-crate:
-    DO ./.earthly/rust+PUBLISH
+publish-crates:
+    DO ./.earthly/rust+PUBLISH --CRATE="clawless-derive"
+    DO ./.earthly/rust+PUBLISH --CRATE="clawless"
 
 test-rust:
     DO ./.earthly/rust+TEST

--- a/crates/clawless-cli/Cargo.toml
+++ b/crates/clawless-cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { workspace = true }
-clawless = { workspace = true }
+clawless = { path = "../clawless" }
 
 [dev-dependencies]
 trycmd = "0.15.9"

--- a/crates/clawless/Cargo.toml
+++ b/crates/clawless/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 
 [dependencies]
 clap = { workspace = true }
-clawless-derive = { workspace = true }
+clawless-derive = { path = "../clawless-derive", version = "=0.0.0" }
 inventory = { workspace = true }
 getset = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
The repository has been prepared for automating releases to crates.io. New labels have been added to the repository that can be used to tag pull requests so that they are included in the changelog, and a new GitHub Actions workflow has been added that runs after a new GitHub release is published and pushes the crates in the repository to crates.io. Together, these features make it easy to publish new versions using GitHub's tooling.