### PR TITLE
Ease restrictions on dependency versions

### DIFF
--- a/crates/clawless-derive/Cargo.toml
+++ b/crates/clawless-derive/Cargo.toml
@@ -12,8 +12,8 @@ rust-version.workspace = true
 proc-macro = true
 
 [dependencies]
-darling = "0.20.11"
+darling = "0.20"
 getset = { workspace = true }
-proc-macro2 = "1.0.95"
-quote = "1.0.40"
-syn = { version = "2.0.101", features = ["full"] }
+proc-macro2 = "1.0.74"
+quote = "1.0.35"
+syn = { version = "2.0.46", features = ["full"] }


### PR DESCRIPTION
The versions of the dependencies for `clawless-derive` have been eased to support a wider range of versions.