### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2025-07-11
+
+### Changed
+
+- Increase minimum version of `proc-macro2` dependency to `1.0.86`
+
 ## [0.1.0] - 2025-06-20
 
 ### Added
 
 - Initial prototype featuring the `clawless!`, `app!`, and `#[command]` macros
 
+[0.2.0]: https://github.com/aonyx-rs/clawless/releases/tag/v0.2.0
 [0.1.0]: https://github.com/aonyx-rs/clawless/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clawless"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "clawless-derive",
@@ -159,7 +159,7 @@ dependencies = [
 
 [[package]]
 name = "clawless-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "clawless",
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "clawless-derive"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "darling",
  "getset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 license = "Apache-2.0 OR MIT"

--- a/crates/clawless/Cargo.toml
+++ b/crates/clawless/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 
 [dependencies]
 clap = { workspace = true }
-clawless-derive = { path = "../clawless-derive", version = "=0.1.0" }
+clawless-derive = { path = "../clawless-derive", version = "=0.2.0" }
 inventory = { workspace = true }
 getset = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
This release bumps the minimum supported version of the `proc-macro2` dependency to `1.0.86`.