### PR TITLE
Use shared configuration preset for Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,19 +1,8 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["config:base"],
-
-  assignees: ["jdno"],
-  reviewers: ["jdno"],
-
-  automerge: true,
-  dependencyDashboard: false,
-  semanticCommits: "disabled",
-
-  "pre-commit": {
-    enabled: true,
-  },
+  extends: ["github>aonyx-rs/renovate-config"],
 
   dockerfile: {
-    fileMatch: ["^Earthfile$"],
+    fileMatch: ["Earthfile$"],
   },
 }


### PR DESCRIPTION
Renovate supports shared configuration presets, which we use in the Aonyx organization to provide a sensible default configuration to our projects. This repository has been updated to use said preset.