### PR TITLE
Rename the error types

### DIFF
--- a/crates/clawless-cli/src/new.rs
+++ b/crates/clawless-cli/src/new.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use clawless::{command, Result};
+use clawless::{command, CommandResult};
 
 mod subcommand;
 
@@ -10,6 +10,6 @@ pub struct NewArgs {}
 ///
 /// This command creates a new project and sets it up for clawless.
 #[command(noop = true)]
-pub async fn new(_args: NewArgs) -> Result {
+pub async fn new(_args: NewArgs) -> CommandResult {
     Ok(())
 }

--- a/crates/clawless-cli/src/new/subcommand.rs
+++ b/crates/clawless-cli/src/new/subcommand.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use clawless::{command, Result};
+use clawless::{command, CommandResult};
 
 #[derive(Debug, Args)]
 pub struct SubcommandArgs {
@@ -8,7 +8,7 @@ pub struct SubcommandArgs {
 }
 
 #[command]
-pub async fn subcommand(args: SubcommandArgs) -> Result {
+pub async fn subcommand(args: SubcommandArgs) -> CommandResult {
     println!("Running a subcommand: {}", args.name);
     Ok(())
 }

--- a/crates/clawless-derive/src/command.rs
+++ b/crates/clawless-derive/src/command.rs
@@ -78,7 +78,7 @@ impl CommandGenerator {
         let inventory_name = inventory_name();
 
         quote! {
-            pub async fn #wrapper_function_name(args: clap::ArgMatches) -> clawless::Result {
+            pub async fn #wrapper_function_name(args: clap::ArgMatches) -> clawless::CommandResult {
                 for subcommand in clawless::inventory::iter::<#inventory_name> {
                     if let Some(matches) = args.subcommand_matches(subcommand.name) {
                         return (subcommand.func)(matches.clone()).await;

--- a/crates/clawless-derive/src/inventory.rs
+++ b/crates/clawless-derive/src/inventory.rs
@@ -22,7 +22,7 @@ impl<'a> InventoryGenerator<'a> {
             struct #inventory_name {
                 name: &'static str,
                 init: fn() -> clap::Command,
-                func: fn(clap::ArgMatches) -> std::pin::Pin<Box<dyn std::future::Future<Output = clawless::Result>>>,
+                func: fn(clap::ArgMatches) -> std::pin::Pin<Box<dyn std::future::Future<Output = clawless::CommandResult>>>,
             }
             clawless::inventory::collect!(#inventory_name);
         }

--- a/crates/clawless-derive/src/lib.rs
+++ b/crates/clawless-derive/src/lib.rs
@@ -28,7 +28,7 @@ mod inventory;
 pub fn main(_input: TokenStream) -> TokenStream {
     let output = quote! {
         #[clawless::command(noop = true, root = true)]
-        async fn clawless() -> clawless::Result {
+        async fn clawless() -> clawless::CommandResult {
             Ok(())
         }
 

--- a/crates/clawless/src/error.rs
+++ b/crates/clawless/src/error.rs
@@ -1,4 +1,20 @@
-pub use anyhow::{Context, Error};
+pub use anyhow::Error;
+
+/// Trait for adding context to errors
+///
+/// This is a re-export of `anyhow::Context` that provides the `.context()` method
+/// for adding contextual information to errors. It's renamed to avoid conflicts
+/// with a future `clawless::Context` type for application state.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use clawless::ErrorContext;
+///
+/// let result = some_operation()
+///     .context("Failed to perform operation")?;
+/// ```
+pub use anyhow::Context as ErrorContext;
 
 /// Result type for Clawless commands
 ///
@@ -7,12 +23,13 @@ pub use anyhow::{Context, Error};
 /// command, it will cause the CLI to fail and exit with an error message.
 ///
 /// To make it easier to handle errors when implementing commands, every command
-/// handler returns a `Result` type. This makes it possible to use the question
-/// mark `?` operator and return early when an unrecoverable error occurs.
+/// handler returns a `CommandResult` type. This makes it possible to use the
+/// question mark `?` operator and return early when an unrecoverable error
+/// occurs.
 ///
-/// The `Result` is a wrapper around the `anyhow::Result` type, which provides
+/// The `CommandResult` is a type alias for `anyhow::Result<()>`, which provides
 /// a more ergonomic way to handle arbitrary errors. Since it isn't possible to
-/// recover the error anyways, we do not need to provide a specific error type
+/// recover the error anyway, we do not need to provide a specific error type
 /// that a caller could handle gracefully. Similarly, commands do not need to
-/// return a value and thus the `Result` type is always `()`.
-pub type Result = anyhow::Result<()>;
+/// return a value, thus the result is always `Result<()>`.
+pub type CommandResult = anyhow::Result<()>;

--- a/crates/clawless/src/lib.rs
+++ b/crates/clawless/src/lib.rs
@@ -3,7 +3,7 @@
 
 pub use clawless_derive::{command, main};
 
-pub use self::error::{Context, Error, Result};
+pub use self::error::{CommandResult, Error, ErrorContext};
 
 mod error;
 

--- a/examples/hello-world/src/greet.rs
+++ b/examples/hello-world/src/greet.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use clawless::{command, Result};
+use clawless::{command, CommandResult};
 
 /// Arguments for the `greet` command
 ///
@@ -17,7 +17,7 @@ pub struct GreetArgs {
 /// This command prints a greeting message to the console using the provided name. If no name is
 /// given, the greeting default to "Hello, World!".
 #[command]
-pub async fn greet(args: GreetArgs) -> Result {
+pub async fn greet(args: GreetArgs) -> CommandResult {
     println!("Hello, {}!", args.name);
     Ok(())
 }


### PR DESCRIPTION
The error types have been renamed to avoid confusion and avoid potential naming conflicts in the future. The previously re-exported `Result` type was unintuitive, since it did not follow the established convention of including the return type with the type (e.g. `Result<()>`). By renaming the re-export to `CommandResult`, we hope that this confusion is avoided.

We also renamed the re-export of `anyhow::Context`, since we already have an issue in the backlog to provide context to commands (see #32). By renaming the context trait now, we avoid a naming conflict in the future.