### PR TITLE
Improve the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the framework for your own projects.
 
 Clawless is in a very early prototyping phase and not considered ready for
 production use. Follow the project and check out its open issues to understand
-the frameworks's current limitations and future roadmap.
+the framework's current limitations and future roadmap.
 
 ## License
 

--- a/crates/clawless-derive/src/lib.rs
+++ b/crates/clawless-derive/src/lib.rs
@@ -47,18 +47,19 @@ pub fn main(_input: TokenStream) -> TokenStream {
 /// Add a command to a Clawless application
 ///
 /// This macro attribute can be used to register a function as a (sub)command in
-/// Clawless application. The name of the function will be used as the name of
+/// a Clawless application. The name of the function will be used as the name of
 /// the command, and it will be automatically registered as a subcommand under
 /// its parent module.
 ///
-/// Command functions expect a single argument, which is a `clap::Args` struct
-/// with arguments that will be passed to the command.
+/// Command functions can optionally accept a single argument, which must be a
+/// `clap::Args` struct with arguments that will be passed to the command. If no
+/// argument is provided, the command takes no parameters.
 ///
 /// # Example
 ///
 /// ```rust,ignore
 /// use clap::Args;
-/// use clawless::command;
+/// use clawless::{command, CommandResult};
 ///
 /// #[derive(Debug, Args)]
 /// pub struct CommandArgs {
@@ -67,8 +68,9 @@ pub fn main(_input: TokenStream) -> TokenStream {
 /// }
 ///
 /// #[command]
-/// pub async fn command(args: CommandArgs) {
+/// pub async fn command(args: CommandArgs) -> CommandResult {
 ///     println!("Running a command: {}", args.name);
+///     Ok(())
 /// }
 /// ```
 #[proc_macro_attribute]

--- a/crates/clawless/README.md
+++ b/crates/clawless/README.md
@@ -20,22 +20,15 @@ the crate, open `src/main.rs` and replace the generated contents with the
 following snippet:
 
 ```rust,ignore
-clawless::main()!;
+clawless::main!();
 ```
 
-You can now start creating commands for your application. Inside `src/main.rs`,
-add the following line at the top:
-
-```rust
-pub mod command;
-```
-
-Then go ahead, create `src/command.rs`, and add a struct and a function to
-the file:
+You can now start creating commands for your application by creating command
+modules. Create `src/command.rs`, and add a struct and a function to the file:
 
 ```rust
 use clap::Args;
-use clawless::command;
+use clawless::{command, CommandResult};
 
 #[derive(Debug, Args)]
 pub struct CommandArgs {
@@ -44,8 +37,9 @@ pub struct CommandArgs {
 }
 
 #[command]
-pub async fn command(args: CommandArgs) {
+pub async fn command(args: CommandArgs) -> CommandResult {
     println!("Running a command: {}", args.name);
+    Ok(())
 }
 ```
 

--- a/crates/clawless/src/error.rs
+++ b/crates/clawless/src/error.rs
@@ -29,7 +29,7 @@ pub use anyhow::Context as ErrorContext;
 ///
 /// The `CommandResult` is a type alias for `anyhow::Result<()>`, which provides
 /// a more ergonomic way to handle arbitrary errors. Since it isn't possible to
-/// recover the error anyway, we do not need to provide a specific error type
+/// recover from the error, we do not need to provide a specific error type
 /// that a caller could handle gracefully. Similarly, commands do not need to
 /// return a value, thus the result is always `Result<()>`.
 pub type CommandResult = anyhow::Result<()>;


### PR DESCRIPTION
Some grammar and spelling mistakes have been fixed in the documentation, and the examples have been updated to use the current API of clawless.