### PR TITLE
Fix overriding the Rust version in checks

### DIFF
--- a/justfile
+++ b/justfile
@@ -49,6 +49,9 @@ check-minimal-deps:
         exit 1
     fi
 
+    # Install the nightly toolchain if not already installed
+    rustup install nightly
+
     # Update dependencies to minimal versions
     rustup run nightly cargo update -Z direct-minimal-versions
 


### PR DESCRIPTION
Overriding the Rust version in checks using the `rustup override set` command did not work due to issues with Flox. A better approach seems to be to run commands through `rustup run`, which works reliably even inside Flox.