### PR TITLE
Check for unused dependencies

### DIFF
--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -3,6 +3,9 @@
   "manifest": {
     "version": 1,
     "install": {
+      "cargo-udeps": {
+        "pkg-path": "cargo-udeps"
+      },
       "clang": {
         "pkg-path": "clang",
         "systems": [
@@ -172,6 +175,122 @@
       },
       "system": "x86_64-linux",
       "group": "rust-toolchain",
+      "priority": 5
+    },
+    {
+      "attr_path": "cargo-udeps",
+      "broken": false,
+      "derivation": "/nix/store/va570xk5pq3m10g6454z1aznldqdsif8-cargo-udeps-0.1.59.drv",
+      "description": "Find unused dependencies in Cargo.toml",
+      "install_id": "cargo-udeps",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+      "name": "cargo-udeps-0.1.59",
+      "pname": "cargo-udeps",
+      "rev": "b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+      "rev_count": 888552,
+      "rev_date": "2025-11-02T19:18:41Z",
+      "scrape_date": "2025-11-04T00:35:18.218411Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.1.59",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/lh6p2j1ggyyr1y3g8gxd4p8byn9b4vh2-cargo-udeps-0.1.59"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "cargo-udeps",
+      "broken": false,
+      "derivation": "/nix/store/370w3qsv3s59xmzfjpcx4xyjxqpj9vnj-cargo-udeps-0.1.59.drv",
+      "description": "Find unused dependencies in Cargo.toml",
+      "install_id": "cargo-udeps",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+      "name": "cargo-udeps-0.1.59",
+      "pname": "cargo-udeps",
+      "rev": "b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+      "rev_count": 888552,
+      "rev_date": "2025-11-02T19:18:41Z",
+      "scrape_date": "2025-11-05T16:28:57.480156Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.1.59",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/g49ygvz93yl5lhgfvala9lc8liycx4m6-cargo-udeps-0.1.59"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "cargo-udeps",
+      "broken": false,
+      "derivation": "/nix/store/8kgazp7xvs6jjxkl7lpdk2fbzmg9ljll-cargo-udeps-0.1.59.drv",
+      "description": "Find unused dependencies in Cargo.toml",
+      "install_id": "cargo-udeps",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+      "name": "cargo-udeps-0.1.59",
+      "pname": "cargo-udeps",
+      "rev": "b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+      "rev_count": 888552,
+      "rev_date": "2025-11-02T19:18:41Z",
+      "scrape_date": "2025-11-05T16:54:57.256185Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.1.59",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/r94xl9sasrx19rvcggamvh0k11aq8v2l-cargo-udeps-0.1.59"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "cargo-udeps",
+      "broken": false,
+      "derivation": "/nix/store/wahhy1pdwnp5a4lmkvvs59ry1h23s6la-cargo-udeps-0.1.59.drv",
+      "description": "Find unused dependencies in Cargo.toml",
+      "install_id": "cargo-udeps",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+      "name": "cargo-udeps-0.1.59",
+      "pname": "cargo-udeps",
+      "rev": "b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+      "rev_count": 888552,
+      "rev_date": "2025-11-02T19:18:41Z",
+      "scrape_date": "2025-11-05T17:20:46.767956Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.1.59",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/0qm7ajnyl617zgllxd84854v0w1z6k6j-cargo-udeps-0.1.59"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
       "priority": 5
     },
     {

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -21,6 +21,7 @@ gcc.pkg-path = "gcc"
 gcc.systems = ["aarch64-linux", "x86_64-linux"]
 
 # Local development tools
+cargo-udeps.pkg-path = "cargo-udeps"
 git.pkg-path = "git"
 just.pkg-path = "just"
 markdownlint-cli.pkg-path = "markdownlint-cli"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,12 +167,9 @@ name = "clawless"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "clap",
  "clawless-derive",
- "getset",
  "inventory",
  "tokio",
- "typed-builder",
 ]
 
 [[package]]
@@ -189,7 +186,6 @@ name = "clawless-derive"
 version = "0.2.0"
 dependencies = [
  "darling",
- "getset",
  "indoc",
  "proc-macro2",
  "quote",
@@ -348,18 +344,6 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
-]
-
-[[package]]
-name = "getset"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
-dependencies = [
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -546,28 +530,6 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -874,26 +836,6 @@ dependencies = [
  "shlex",
  "snapbox",
  "toml_edit",
-]
-
-[[package]]
-name = "typed-builder"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0dd654273fc253fde1df4172c31fb6615cf8b041d3a4008a028ef8b1119e66"
-dependencies = [
- "typed-builder-macro",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c26257f448222014296978b2c8456e2cad4de308c35bdb1e383acd569ef5b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/crates/clawless-derive/Cargo.toml
+++ b/crates/clawless-derive/Cargo.toml
@@ -13,7 +13,6 @@ proc-macro = true
 
 [dependencies]
 darling = "0.21"
-getset = { workspace = true }
 proc-macro2 = "1.0.86"
 quote = "1.0.35"
 syn = { version = "2.0.46", features = ["full"] }

--- a/crates/clawless/Cargo.toml
+++ b/crates/clawless/Cargo.toml
@@ -10,9 +10,6 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { workspace = true }
 clawless-derive = { path = "../clawless-derive", version = "=0.2.0" }
 inventory = { workspace = true }
-getset = { workspace = true }
 tokio = { workspace = true }
-typed-builder = { workspace = true }

--- a/justfile
+++ b/justfile
@@ -71,6 +71,16 @@ check-msrv:
     # Run tests using the MSRV
     RUSTFLAGS="-D deprecated" rustup run "${MSRV}" cargo check --all-features --all-targets
 
+# Check that all dependencies in Cargo.toml are used
+check-unused-deps:
+    #!/usr/bin/env bash
+
+    # Install the nightly toolchain if not already installed
+    rustup install nightly
+
+    # Check for unused dependencies
+    rustup run nightly cargo udeps
+
 # Format JSON files
 format-json fix="false": (prettier fix "{json,json5}")
 


### PR DESCRIPTION
A new recipe has been added to just that checks for unused dependencies in this project. The check itself is run with [cargo-udeps], which has been added to the Flox environment.

[cargo-udeps]: https://github.com/est31/cargo-udeps