### PR TITLE
Re-export clap dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,7 @@ name = "clawless"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "clap",
  "clawless-derive",
  "inventory",
  "tokio",
@@ -176,7 +177,6 @@ dependencies = [
 name = "clawless-cli"
 version = "0.2.0"
 dependencies = [
- "clap",
  "clawless",
  "trycmd",
 ]
@@ -369,7 +369,6 @@ name = "hello-world"
 version = "0.2.0"
 dependencies = [
  "assert_cmd",
- "clap",
  "clawless",
  "predicates",
 ]

--- a/crates/clawless-cli/Cargo.toml
+++ b/crates/clawless-cli/Cargo.toml
@@ -13,7 +13,6 @@ name = "clawless"
 path = "src/main.rs"
 
 [dependencies]
-clap = { workspace = true }
 clawless = { path = "../clawless" }
 
 [dev-dependencies]

--- a/crates/clawless-cli/src/new.rs
+++ b/crates/clawless-cli/src/new.rs
@@ -1,5 +1,4 @@
-use clap::Args;
-use clawless::{CommandResult, command};
+use clawless::prelude::*;
 
 mod subcommand;
 

--- a/crates/clawless-cli/src/new/subcommand.rs
+++ b/crates/clawless-cli/src/new/subcommand.rs
@@ -1,5 +1,4 @@
-use clap::Args;
-use clawless::{CommandResult, command};
+use clawless::prelude::*;
 
 #[derive(Debug, Args)]
 pub struct SubcommandArgs {

--- a/crates/clawless-derive/src/command.rs
+++ b/crates/clawless-derive/src/command.rs
@@ -60,7 +60,7 @@ impl CommandGenerator {
         let inventory_name = inventory_name();
 
         quote! {
-            pub fn #function_name() -> clap::Command {
+            pub fn #function_name() -> clawless::clap::Command {
                 let mut command = #command_new;
 
                 for subcommand in clawless::inventory::iter::<#inventory_name> {
@@ -78,7 +78,7 @@ impl CommandGenerator {
         let inventory_name = inventory_name();
 
         quote! {
-            pub async fn #wrapper_function_name(args: clap::ArgMatches) -> clawless::CommandResult {
+            pub async fn #wrapper_function_name(args: clawless::clap::ArgMatches) -> clawless::CommandResult {
                 for subcommand in clawless::inventory::iter::<#inventory_name> {
                     if let Some(matches) = args.subcommand_matches(subcommand.name) {
                         return (subcommand.func)(matches.clone()).await;
@@ -97,16 +97,16 @@ impl CommandGenerator {
 
         let mut command = match args_type {
             Some(ty) => quote! {
-                #ty::augment_args(clap::Command::new(#command_name))
+                #ty::augment_args(clawless::clap::Command::new(#command_name))
             },
             None => quote! {
-                clap::Command::new(#command_name)
+                clawless::clap::Command::new(#command_name)
             },
         };
 
         if self.is_root() {
             command = quote! {
-                #command.about(clap::crate_description!())
+                #command.about(clawless::clap::crate_description!())
             };
         } else if let Some(docs) = docs {
             let Documentation { short, long } = docs;
@@ -131,7 +131,7 @@ impl CommandGenerator {
 
         match args_type {
             Some(ty) => quote! {
-                use clap::FromArgMatches;
+                use clawless::clap::FromArgMatches;
                 let args = #ty::from_arg_matches(&args).unwrap();
                 #command(args).await
             },
@@ -301,7 +301,7 @@ mod tests {
 
         let actual = generator.command_new();
         let expected = quote! {
-            Args::augment_args(clap::Command::new("foo"))
+            Args::augment_args(clawless::clap::Command::new("foo"))
         };
 
         assert_eq!(actual.to_string(), expected.to_string());
@@ -313,7 +313,7 @@ mod tests {
 
         let actual = generator.command_new();
         let expected = quote! {
-            clap::Command::new("foo")
+            clawless::clap::Command::new("foo")
         };
 
         assert_eq!(actual.to_string(), expected.to_string());
@@ -325,7 +325,7 @@ mod tests {
 
         let actual = generator.command_new();
         let expected = quote! {
-            Args::augment_args(clap::Command::new("foo")).arg_required_else_help(true)
+            Args::augment_args(clawless::clap::Command::new("foo")).arg_required_else_help(true)
         };
 
         assert_eq!(actual.to_string(), expected.to_string());
@@ -337,7 +337,7 @@ mod tests {
 
         let actual = generator.wrapper_function_body();
         let expected = quote! {
-            use clap::FromArgMatches;
+            use clawless::clap::FromArgMatches;
             let args = Args::from_arg_matches(&args).unwrap();
             foo(args).await
         };

--- a/crates/clawless-derive/src/inventory.rs
+++ b/crates/clawless-derive/src/inventory.rs
@@ -21,8 +21,8 @@ impl<'a> InventoryGenerator<'a> {
         quote! {
             struct #inventory_name {
                 name: &'static str,
-                init: fn() -> clap::Command,
-                func: fn(clap::ArgMatches) -> std::pin::Pin<Box<dyn std::future::Future<Output = clawless::CommandResult>>>,
+                init: fn() -> clawless::clap::Command,
+                func: fn(clawless::clap::ArgMatches) -> std::pin::Pin<Box<dyn std::future::Future<Output = clawless::CommandResult>>>,
             }
             clawless::inventory::collect!(#inventory_name);
         }

--- a/crates/clawless-derive/src/lib.rs
+++ b/crates/clawless-derive/src/lib.rs
@@ -58,8 +58,7 @@ pub fn main(_input: TokenStream) -> TokenStream {
 /// # Example
 ///
 /// ```rust,ignore
-/// use clap::Args;
-/// use clawless::{command, CommandResult};
+/// use clawless::prelude::*;
 ///
 /// #[derive(Debug, Args)]
 /// pub struct CommandArgs {

--- a/crates/clawless/Cargo.toml
+++ b/crates/clawless/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+clap = { workspace = true }
 clawless-derive = { path = "../clawless-derive", version = "=0.2.0" }
 inventory = { workspace = true }
 tokio = { workspace = true }

--- a/crates/clawless/README.md
+++ b/crates/clawless/README.md
@@ -27,8 +27,7 @@ You can now start creating commands for your application by creating command
 modules. Create `src/command.rs`, and add a struct and a function to the file:
 
 ```rust
-use clap::Args;
-use clawless::{command, CommandResult};
+use clawless::prelude::*;
 
 #[derive(Debug, Args)]
 pub struct CommandArgs {

--- a/crates/clawless/src/lib.rs
+++ b/crates/clawless/src/lib.rs
@@ -1,11 +1,27 @@
 #![cfg_attr(not(doctest),doc = include_str!("../README.md"))]
 #![warn(missing_docs)]
 
-pub use clawless_derive::{command, main};
+/// A prelude module to easily import Clawless essentials
+///
+/// This module re-exports the most commonly used items from the Clawless crate. By importing
+/// everything from this module, users can conveniently access the necessary types and traits to
+/// define and run commands without needing to import each item individually.
+pub mod prelude {
+    pub use super::error::{CommandResult, Error, ErrorContext};
 
-pub use self::error::{CommandResult, Error, ErrorContext};
+    pub use clap;
+    pub use clap::{Args, FromArgMatches};
+    pub use clawless_derive::{command, main};
+}
+
+pub use clawless_derive::{command, main};
+pub use error::{CommandResult, Error, ErrorContext};
 
 mod error;
+
+// Re-export the clap crate for use with the `clawless-derive` crate
+#[doc(hidden)]
+pub use clap;
 
 // Re-export the inventory crate for use with the `clawless-derive` crate
 #[doc(hidden)]

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -13,7 +13,6 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-clap = { workspace = true }
 clawless = { workspace = true }
 
 [dev-dependencies]

--- a/examples/hello-world/src/greet.rs
+++ b/examples/hello-world/src/greet.rs
@@ -1,5 +1,4 @@
-use clap::Args;
-use clawless::{CommandResult, command};
+use clawless::prelude::*;
 
 /// Arguments for the `greet` command
 ///


### PR DESCRIPTION
`clap` has been re-exported in the `clawless` crate so that users don't need to add it to their own projects. This is a first step towards hiding `clap` as an implementation detail, but it is still part of `clawless`'s public API through the `#[arg]` annotation.