### PR TITLE
Ignore directories when linting Markdown files

### DIFF
--- a/justfile
+++ b/justfile
@@ -104,7 +104,7 @@ lint-github-actions:
 
 # Lint Markdown files
 lint-markdown:
-    markdownlint **/*.md
+    markdownlint --ignore-path .gitignore **/*.md
 
 # Lint Rust files
 lint-rust:


### PR DESCRIPTION
Linting Markdown files failed when `cargo doc` had been run, since files in `target/doc` did not match the standards in our project. To fix this, we are now passing an argument to the `markdownlint-cli` that ignores all files and directories from the `.gitignore` file. This should reduce the amount of configuration we need to maintain and provide a good enough filter to avoid future false negatives.