### PR TITLE
Return `Result` from `clawless::main!`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ edition = "2024"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/aonyx-ai/clawless.git"
 
-# typed-builder uses a if-let-chain, which was only stabilized in Rust 1.88.0
+# typed-builder uses an if-let-chain, which was only stabilized in Rust 1.88.0
 # https://github.com/rust-lang/rust/issues/53667
 rust-version = "1.88.0"
 
 [workspace.dependencies]
-anyhow = "1.0.14"
+anyhow = "1.0.16"
 clap = { version = "4.3", features = ["cargo", "derive"] }
 clawless = { path = "crates/clawless" }
 inventory = "0.3"

--- a/crates/clawless-derive/src/lib.rs
+++ b/crates/clawless-derive/src/lib.rs
@@ -32,13 +32,14 @@ pub fn main(_input: TokenStream) -> TokenStream {
             Ok(())
         }
 
-        fn main() {
-            let rt = clawless::tokio::runtime::Runtime::new().unwrap();
+        fn main() -> Result<(), Box<dyn std::error::Error>> {
+            let rt = clawless::tokio::runtime::Runtime::new()?;
             rt.block_on(async {
                 let app = clawless_init();
                 clawless_exec(app.get_matches()).await
-            })
-            .unwrap();
+            })?;
+
+            Ok(())
         }
     };
     output.into()


### PR DESCRIPTION
The proc macro for `clawless::main!` has been modified to return a `Result`, making it possible to use the `?` operator when initializing the async runtime and scheduling the user's function on it. While this is functionally very similar to what was there before, it allows us to remove two `unwrap` statements from our code.