### PR TITLE
Add flag to force checks to run

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,11 +22,11 @@ build-docs:
     cargo doc --all-features --no-deps
 
 # Check that clawless builds with the latest dependencies
-check-latest-deps:
+check-latest-deps force="false":
     #!/usr/bin/env bash
 
     # Abort if git is not clean (but ignore Flox's manifest.lock)
-    if [[ -n $(git status --porcelain -- ':!.flox/env/manifest.lock') ]]; then
+    if [[ {{force}} != "true" && -n $(git status --porcelain -- ':!.flox/env/manifest.lock') ]]; then
         echo "Git working directory is not clean. Commit or stash changes before running this recipe. Aborting."
         git status --porcelain
         exit 1
@@ -39,11 +39,11 @@ check-latest-deps:
     RUSTFLAGS="-D deprecated" cargo test --all-features --all-targets --locked
 
 # Check that clawless builds with the minimal dependencies
-check-minimal-deps:
+check-minimal-deps force="false":
     #!/usr/bin/env bash
 
     # Abort if git is not clean (but ignore Flox's manifest.lock)
-    if [[ -n $(git status --porcelain -- ':!.flox/env/manifest.lock') ]]; then
+    if [[ {{force}} != "true" && -n $(git status --porcelain -- ':!.flox/env/manifest.lock') ]]; then
         echo "Git working directory is not clean. Commit or stash changes before running this recipe. Aborting."
         git status --porcelain
         exit 1


### PR DESCRIPTION
The checks for latest and minimum dependency versions mess with the local filesystem, which is why they have a guard clause that checks whether the git repository is clean before running. This works well for regular check runs, but is annoying when trying to fix broken versions. In these cases, it is easier to allow a dirty state for faster iteration. A parameter has been added to the recipes to allow them to run whether or not git is clean.