### PR TITLE
Declare all dependencies in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,11 @@ rust-version = "1.88.0"
 anyhow = "1.0.16"
 clap = { version = "4.3", features = ["cargo", "derive"] }
 clawless = { path = "crates/clawless" }
+darling = ">=0.21,<1"
+indoc = "2"
 inventory = "0.3"
-getset = "0.1"
+proc-macro2 = "1.0.86"
+quote = "1.0.35"
+syn = { version = "2.0.46", features = ["full"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-typed-builder = "0"
+trycmd = ">=0.4,<1"

--- a/crates/clawless-cli/Cargo.toml
+++ b/crates/clawless-cli/Cargo.toml
@@ -16,4 +16,4 @@ path = "src/main.rs"
 clawless = { path = "../clawless" }
 
 [dev-dependencies]
-trycmd = "0.15.9"
+trycmd = { workspace = true }

--- a/crates/clawless-derive/Cargo.toml
+++ b/crates/clawless-derive/Cargo.toml
@@ -12,10 +12,10 @@ rust-version.workspace = true
 proc-macro = true
 
 [dependencies]
-darling = "0.21"
-proc-macro2 = "1.0.86"
-quote = "1.0.35"
-syn = { version = "2.0.46", features = ["full"] }
+darling = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
 
 [dev-dependencies]
-indoc = "2.0.6"
+indoc = { workspace = true }


### PR DESCRIPTION
All dependencies and their versions are now centrally managed in the workspace's `Cargo.toml`, and referenced in the crates as workspace dependencies. This makes it easier to ensure we use a single, consistent version of each crate and it provides a holistic overview of all the dependencies used by clawless.