### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2025-11-21
+
+### Added
+
+- Document CLIs using doc comments
+- Return result type from commands
+- Return `Result` from `clawless::main!`
+
+### Changed
+
+- Refactor the macros to simplify the crate's API
+- Rename the error types
+- Upgrade to Rust edition 2024
+- Re-export clap dependency
+- Reintroduce `commands` module
+
 ## [0.2.0] - 2025-07-11
 
 ### Changed
@@ -20,5 +36,6 @@ and this project adheres to
 
 - Initial prototype featuring the `clawless!`, `app!`, and `#[command]` macros
 
+[0.3.0]: https://github.com/aonyx-ai/clawless/releases/tag/v0.3.0
 [0.2.0]: https://github.com/aonyx-ai/clawless/releases/tag/v0.2.0
 [0.1.0]: https://github.com/aonyx-ai/clawless/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "clawless"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "clawless-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clawless",
  "trycmd",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "clawless-derive"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "darling",
  "indoc",
@@ -366,7 +366,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello-world"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "assert_cmd",
  "clawless",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["crates/*", "examples/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 
 license = "Apache-2.0 OR MIT"
@@ -20,6 +20,7 @@ rust-version = "1.88.0"
 anyhow = "1.0.16"
 clap = { version = "4.3", features = ["cargo", "derive"] }
 clawless = { path = "crates/clawless" }
+clawless-derive = { path = "crates/clawless-derive", version = "=0.3.0" }
 darling = ">=0.21,<1"
 indoc = "2"
 inventory = "0.3"

--- a/crates/clawless/Cargo.toml
+++ b/crates/clawless/Cargo.toml
@@ -11,6 +11,6 @@ rust-version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-clawless-derive = { path = "../clawless-derive", version = "=0.2.0" }
+clawless-derive = { workspace = true }
 inventory = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
This release introduces quite a few quality of life improvements to Clawless's API:

- Commands can now be documented for users using doc comments
- Commands return a `Result`, which simplifies error handling
- The `app!` macro has been replaced by a simpler `commands!` macro
- `clap` is no re-exported and no longer required as a third-party dependency

Please check out the release notes on GitHub for a full list of changes and links to the relevant pull requests with more information.