### PR TITLE
Pass a `Context` to commands

### DIFF
--- a/crates/clawless-cli/src/commands/new.rs
+++ b/crates/clawless-cli/src/commands/new.rs
@@ -9,6 +9,6 @@ pub struct NewArgs {}
 ///
 /// This command creates a new project and sets it up for clawless.
 #[command(noop = true)]
-pub async fn new(_args: NewArgs) -> CommandResult {
+pub async fn new(_args: NewArgs, _context: Context) -> CommandResult {
     Ok(())
 }

--- a/crates/clawless-cli/src/commands/new/subcommand.rs
+++ b/crates/clawless-cli/src/commands/new/subcommand.rs
@@ -7,7 +7,7 @@ pub struct SubcommandArgs {
 }
 
 #[command]
-pub async fn subcommand(args: SubcommandArgs) -> CommandResult {
+pub async fn subcommand(args: SubcommandArgs, _context: Context) -> CommandResult {
     println!("Running a subcommand: {}", args.name);
     Ok(())
 }

--- a/crates/clawless-derive/src/inventory.rs
+++ b/crates/clawless-derive/src/inventory.rs
@@ -22,7 +22,7 @@ impl<'a> InventoryGenerator<'a> {
             struct #inventory_name {
                 name: &'static str,
                 init: fn() -> clawless::clap::Command,
-                func: fn(clawless::clap::ArgMatches) -> std::pin::Pin<Box<dyn std::future::Future<Output = clawless::CommandResult>>>,
+                func: fn(clawless::clap::ArgMatches, clawless::context::Context) -> std::pin::Pin<Box<dyn std::future::Future<Output = clawless::CommandResult>>>,
             }
             clawless::inventory::collect!(#inventory_name);
         }
@@ -42,7 +42,7 @@ impl<'a> InventoryGenerator<'a> {
             clawless::inventory::submit!(super::#inventory_name {
                 name: #command,
                 init: #init_fn_name,
-                func: |args| Box::pin(#wrapper_fn_name(args)),
+                func: |args, context| Box::pin(#wrapper_fn_name(args, context)),
             });
         }
     }

--- a/crates/clawless/README.md
+++ b/crates/clawless/README.md
@@ -46,7 +46,7 @@ pub struct GreetArgs {
 }
 
 #[command]
-pub async fn greet(args: GreetArgs) -> CommandResult {
+pub async fn greet(args: GreetArgs, context: Context) -> CommandResult {
     println!("Hello, {}!", args.name);
     Ok(())
 }

--- a/crates/clawless/src/context.rs
+++ b/crates/clawless/src/context.rs
@@ -1,0 +1,64 @@
+//! Context for Clawless commands
+//!
+//! This module defines the `Context` struct, which provides information about the environment that
+//! Clawless commands are executed in, access to shared resources like loggers, and configuration
+//! settings.
+//!
+//! For information on the context that is available to commands, see the fields and methods of the
+//! `Context` struct as well as the types defined in this module.
+
+use anyhow::Result;
+
+/// Context for Clawless commands
+///
+/// This struct provides information about the environment that Clawless commands are executed in,
+/// access to shared resources, and configuration settings. It is passed to each command by the
+/// Clawless runtime when executing commands.
+///
+/// ```rust,ignore
+/// #[derive(Debug, Args)]
+/// pub struct GreetArgs {
+///     name: String,
+/// }
+///
+/// #[command]
+/// pub async fn greet(args: GreetArgs, context: Context) -> CommandResult {
+///     println!("Hello, {}!", args.name);
+///     Ok(())
+/// }
+/// ```
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct Context {}
+
+impl Context {
+    /// Create a new `Context` instance
+    ///
+    /// This function initializes a new `Context` with default settings. Since some parts of the
+    /// context might fail to initialize, this function returns a `Result`.
+    pub fn try_new() -> Result<Self> {
+        Ok(Self::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Context>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Context>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Context>();
+    }
+}

--- a/crates/clawless/src/lib.rs
+++ b/crates/clawless/src/lib.rs
@@ -7,6 +7,7 @@
 /// everything from this module, users can conveniently access the necessary types and traits to
 /// define and run commands without needing to import each item individually.
 pub mod prelude {
+    pub use super::context::*;
     pub use super::error::{CommandResult, Error, ErrorContext};
 
     pub use clap;
@@ -17,6 +18,7 @@ pub mod prelude {
 pub use clawless_derive::{command, commands, main};
 pub use error::{CommandResult, Error, ErrorContext};
 
+pub mod context;
 mod error;
 
 // Re-export the clap crate for use with the `clawless-derive` crate

--- a/examples/hello-world/src/commands/greet.rs
+++ b/examples/hello-world/src/commands/greet.rs
@@ -16,7 +16,7 @@ pub struct GreetArgs {
 /// This command prints a greeting message to the console using the provided name. If no name is
 /// given, the greeting default to "Hello, World!".
 #[command]
-pub async fn greet(args: GreetArgs) -> CommandResult {
+pub async fn greet(args: GreetArgs, _context: Context) -> CommandResult {
     println!("Hello, {}!", args.name);
     Ok(())
 }


### PR DESCRIPTION
The public interface for commands has been changed so that they accept both command-line arguments as well as a context object. The context provides information about the environment that a command runs in, and access to shared resources and configuration settings.

A requirement that this change introduces is that commands MUST accept those two arguments. This will be checked and reported using better error messages in a future commit.

Closes #32 