### PR TITLE
Lower minimal versions for new dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ clap = { version = "4.3", features = ["cargo", "derive"] }
 clawless = { path = "crates/clawless" }
 clawless-derive = { path = "crates/clawless-derive", version = "=0.3.0" }
 darling = ">=0.21,<1"
-getset = "0.1.6"
+getset = ">=0.1,<1"
 indoc = "2"
 inventory = "0.3"
 proc-macro2 = "1.0.86"
@@ -30,5 +30,5 @@ quote = "1.0.35"
 syn = { version = "2.0.46", features = ["full"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 trycmd = ">=0.4,<1"
-typed-builder = "0.23.2"
-typed-fields = "0.6.0"
+typed-builder = ">=0.5,<1"
+typed-fields = ">=0.6,<1"


### PR DESCRIPTION
We added some new dependencies in #133, but did not check what the minimal versions are that we need. This change lowers them to support the widest possible range of versions in our user's codebases.