### PR TITLE
Sort imports when formatting Rust code

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,3 @@
+# We use this unstable feature to have consistent import grouping.
+# https://rust-lang.github.io/rustfmt/?search=#group_imports
+group_imports = "StdExternalCrate"

--- a/crates/clawless-cli/src/commands/new.rs
+++ b/crates/clawless-cli/src/commands/new.rs
@@ -157,6 +157,7 @@ fn create_greeting_command(crate_path: &Path) -> Result<(), Error> {
 #[cfg(test)]
 mod tests {
     use std::fs::{create_dir_all, read_to_string};
+
     use tempfile::TempDir;
 
     use super::*;

--- a/crates/clawless/src/error.rs
+++ b/crates/clawless/src/error.rs
@@ -1,5 +1,3 @@
-pub use anyhow::Error;
-
 /// Trait for adding context to errors
 ///
 /// This is a re-export of `anyhow::Context` that provides the `.context()` method
@@ -15,6 +13,7 @@ pub use anyhow::Error;
 ///     .context("Failed to perform operation")?;
 /// ```
 pub use anyhow::Context as ErrorContext;
+pub use anyhow::Error;
 
 /// Result type for Clawless commands
 ///

--- a/crates/clawless/src/lib.rs
+++ b/crates/clawless/src/lib.rs
@@ -7,12 +7,12 @@
 /// everything from this module, users can conveniently access the necessary types and traits to
 /// define and run commands without needing to import each item individually.
 pub mod prelude {
-    pub use super::context::*;
-    pub use super::error::{CommandResult, Error, ErrorContext};
-
     pub use clap;
     pub use clap::{Args, FromArgMatches};
     pub use clawless_derive::{command, commands, main};
+
+    pub use super::context::*;
+    pub use super::error::{CommandResult, Error, ErrorContext};
 }
 
 pub use clawless_derive::{command, commands, main};
@@ -24,11 +24,9 @@ mod error;
 // Re-export the clap crate for use with the `clawless-derive` crate
 #[doc(hidden)]
 pub use clap;
-
 // Re-export the inventory crate for use with the `clawless-derive` crate
 #[doc(hidden)]
 pub use inventory;
-
 // Re-export the tokio crate to run commands in an async runtime
 #[doc(hidden)]
 pub use tokio;

--- a/justfile
+++ b/justfile
@@ -89,7 +89,8 @@ format-markdown fix="false": (prettier fix "md")
 
 # Format Rust files
 format-rust fix="false":
-    cargo fmt {{ if fix != "true" { "--check" } else { "" } }}
+    rustup install -c rustfmt nightly
+    rustup run nightly cargo fmt -- --unstable-features {{ if fix != "true" { "--check" } else { "" } }}
 
 # Format TOML files
 format-toml fix="false":


### PR DESCRIPTION
We are now using the nightly toolchain with the unstable group imports option to format Rust code. This option creates three groups for `use` statements: imports from the standard library, external crates, and imports from the crate itself.

The reason why we do this is to ensure consistency across developers. By letting rustfmt deal with imports, we reduce churn and keep pull request reviews focused on the important changes.