### PR TITLE
Check licenses and sources of dependencies

### DIFF
--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -3,6 +3,9 @@
   "manifest": {
     "version": 1,
     "install": {
+      "cargo-deny": {
+        "pkg-path": "cargo-deny"
+      },
       "cargo-udeps": {
         "pkg-path": "cargo-udeps"
       },
@@ -175,6 +178,122 @@
       },
       "system": "x86_64-linux",
       "group": "rust-toolchain",
+      "priority": 5
+    },
+    {
+      "attr_path": "cargo-deny",
+      "broken": false,
+      "derivation": "/nix/store/0pymkaxm5qhkrf4mb453h96sqljzqhy9-cargo-deny-0.18.5.drv",
+      "description": "Cargo plugin for linting your dependencies",
+      "install_id": "cargo-deny",
+      "license": "[ Apache-2.0, MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+      "name": "cargo-deny-0.18.5",
+      "pname": "cargo-deny",
+      "rev": "b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+      "rev_count": 888552,
+      "rev_date": "2025-11-02T19:18:41Z",
+      "scrape_date": "2025-11-04T00:35:18.207797Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.18.5",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/klgj0jy4smqx1wp1x2cs57zn4n5mkhmv-cargo-deny-0.18.5"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "cargo-deny",
+      "broken": false,
+      "derivation": "/nix/store/54zrbfjka45nl0fwppsbl3n3abzc3z48-cargo-deny-0.18.5.drv",
+      "description": "Cargo plugin for linting your dependencies",
+      "install_id": "cargo-deny",
+      "license": "[ Apache-2.0, MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+      "name": "cargo-deny-0.18.5",
+      "pname": "cargo-deny",
+      "rev": "b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+      "rev_count": 888552,
+      "rev_date": "2025-11-02T19:18:41Z",
+      "scrape_date": "2025-11-05T16:28:57.467525Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.18.5",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/x6njd6w6yak0m024i6jpdg6v38rbf0mn-cargo-deny-0.18.5"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "cargo-deny",
+      "broken": false,
+      "derivation": "/nix/store/vz8kqb7k1qw6bziqfal2a92y4zrlin92-cargo-deny-0.18.5.drv",
+      "description": "Cargo plugin for linting your dependencies",
+      "install_id": "cargo-deny",
+      "license": "[ Apache-2.0, MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+      "name": "cargo-deny-0.18.5",
+      "pname": "cargo-deny",
+      "rev": "b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+      "rev_count": 888552,
+      "rev_date": "2025-11-02T19:18:41Z",
+      "scrape_date": "2025-11-05T16:54:57.245071Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.18.5",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/2h1iym43syqwf2d65daj2bfvgfq0v16a-cargo-deny-0.18.5"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "cargo-deny",
+      "broken": false,
+      "derivation": "/nix/store/l9s1d38pqd9givkjy65y0a7hs8vy7n73-cargo-deny-0.18.5.drv",
+      "description": "Cargo plugin for linting your dependencies",
+      "install_id": "cargo-deny",
+      "license": "[ Apache-2.0, MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+      "name": "cargo-deny-0.18.5",
+      "pname": "cargo-deny",
+      "rev": "b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
+      "rev_count": 888552,
+      "rev_date": "2025-11-02T19:18:41Z",
+      "scrape_date": "2025-11-05T17:20:46.754366Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.18.5",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/mpmj2rzgk70ap8anwq7wa7rz93i92h7c-cargo-deny-0.18.5"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
       "priority": 5
     },
     {

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -21,6 +21,7 @@ gcc.pkg-path = "gcc"
 gcc.systems = ["aarch64-linux", "x86_64-linux"]
 
 # Local development tools
+cargo-deny.pkg-path = "cargo-deny"
 cargo-udeps.pkg-path = "cargo-udeps"
 git.pkg-path = "git"
 just.pkg-path = "just"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.88.0"
 [workspace.dependencies]
 anyhow = "1.0.16"
 clap = { version = "4.3", features = ["cargo", "derive"] }
-clawless = { path = "crates/clawless" }
+clawless = { path = "crates/clawless", version = "=0.3.0" }
 clawless-derive = { path = "crates/clawless-derive", version = "=0.3.0" }
 convert_case = "0.10.0"
 darling = ">=0.21,<1"

--- a/crates/clawless-cli/Cargo.toml
+++ b/crates/clawless-cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-clawless = { path = "../clawless" }
+clawless = { workspace = true }
 convert_case = { workspace = true }
 getset = { workspace = true }
 indoc = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,19 @@
+[output]
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# This option is included since the graphs can be quite large and the addition
+# of features from the crate(s) to all of the graph roots can be far too verbose.
+# This option can be overridden via `--feature-depth` on the cmd line
+feature-depth = 1
+
+[licenses]
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = ["Apache-2.0", "MIT", "Unicode-3.0"]
+
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+# Lint level for when a crate version requirement is `*`
+wildcards = "deny"

--- a/justfile
+++ b/justfile
@@ -38,6 +38,10 @@ check-latest-deps force="false":
     # Run tests to ensure the latest versions are compatible
     RUSTFLAGS="-D deprecated" cargo test --all-features --all-targets --locked
 
+# Check that dependencies have compatible open-source licenses and trusted sources
+check-dependencies:
+    cargo deny check bans licenses sources
+
 # Check that clawless builds with the minimal dependencies
 check-minimal-deps force="false":
     #!/usr/bin/env bash


### PR DESCRIPTION
We are now running [cargo-deny] in CI to ensure our dependencies have valid open source licenses.

[cargo-deny]: https://github.com/EmbarkStudios/cargo-deny