### PR TITLE
Add support for command aliases

### DIFF
--- a/crates/clawless-cli/src/commands/generate.rs
+++ b/crates/clawless-cli/src/commands/generate.rs
@@ -18,7 +18,7 @@ pub struct GenerateArgs {}
 /// ```shell
 /// clawless generate command my-command
 /// ```
-#[command(noop = true)]
+#[command(noop = true, alias = "g")]
 pub async fn generate(_args: GenerateArgs, _context: Context) -> CommandResult {
     Ok(())
 }

--- a/crates/clawless-cli/src/commands/generate/command.rs
+++ b/crates/clawless-cli/src/commands/generate/command.rs
@@ -38,7 +38,7 @@ pub struct GenerateCommandArgs {
 /// ```shell
 /// clawless generate command db/migrate
 /// ```
-#[command]
+#[command(alias = "c")]
 pub async fn command(args: GenerateCommandArgs, context: Context) -> CommandResult {
     // Check is command is running inside a Clawless project
     let project = find_clawless_project(context.current_working_directory())?;

--- a/crates/clawless-cli/src/commands/new.rs
+++ b/crates/clawless-cli/src/commands/new.rs
@@ -31,7 +31,7 @@ pub struct NewArgs {
 /// ```shell
 /// clawless new my-app
 /// ```
-#[command]
+#[command(alias = "n")]
 pub async fn new(args: NewArgs, context: Context) -> CommandResult {
     // Call `cargo new` to create a new binary crate
     let crate_path = create_binary_crate(&context, &args.name)?;

--- a/crates/clawless-cli/tests/commands/generate.toml
+++ b/crates/clawless-cli/tests/commands/generate.toml
@@ -1,4 +1,4 @@
-args = ["generate", "command", "greet/shout"]
+args = ["g", "c", "greet/shout"]
 bin.name = "clawless"
 fs.sandbox = true
 status.code = 0

--- a/crates/clawless-derive/src/lib.rs
+++ b/crates/clawless-derive/src/lib.rs
@@ -83,20 +83,57 @@ pub fn main(_input: TokenStream) -> TokenStream {
 /// 1. An `args` parameter: a `clap::Args` struct with the command's arguments
 /// 2. A `context` parameter: the `Context` providing access to the application environment
 ///
-/// # Example
+/// # Attributes
+///
+/// - `alias = "name"` - Add a visible alias for the command. Can be repeated for multiple aliases.
+/// - `noop = true` - Mark the command as a group that requires a subcommand (no action on its own).
+///
+/// # Examples
+///
+/// Basic command:
 ///
 /// ```rust,ignore
 /// use clawless::prelude::*;
 ///
 /// #[derive(Debug, Args)]
-/// pub struct CommandArgs {
+/// pub struct GreetArgs {
 ///     #[arg(short, long)]
 ///     name: String,
 /// }
 ///
 /// #[command]
-/// pub async fn command(args: CommandArgs, context: Context) -> CommandResult {
-///     println!("Running a command: {}", args.name);
+/// pub async fn greet(args: GreetArgs, context: Context) -> CommandResult {
+///     println!("Hello, {}!", args.name);
+///     Ok(())
+/// }
+/// ```
+///
+/// Command with aliases:
+///
+/// ```rust,ignore
+/// use clawless::prelude::*;
+///
+/// #[derive(Debug, Args)]
+/// pub struct GenerateArgs {}
+///
+/// // Users can run `mycli generate` or `mycli g`
+/// #[command(alias = "g")]
+/// pub async fn generate(args: GenerateArgs, context: Context) -> CommandResult {
+///     Ok(())
+/// }
+/// ```
+///
+/// Command group with alias:
+///
+/// ```rust,ignore
+/// use clawless::prelude::*;
+///
+/// #[derive(Debug, Args)]
+/// pub struct DbArgs {}
+///
+/// // Users can run `mycli db migrate` or `mycli d migrate`
+/// #[command(noop = true, alias = "d")]
+/// pub async fn db(args: DbArgs, context: Context) -> CommandResult {
 ///     Ok(())
 /// }
 /// ```


### PR DESCRIPTION
A new attribute has been added to the `#[command]` macro that enables users to define one or more aliases for a command. Use cases are short commands (e.g. `g` for `generate`) or renaming commands in a backwards compatible manor.