### PR TITLE
Rename the `noop` attribute to `require_subcommand`

### DIFF
--- a/crates/clawless-cli/src/commands/generate.rs
+++ b/crates/clawless-cli/src/commands/generate.rs
@@ -18,7 +18,7 @@ pub struct GenerateArgs {}
 /// ```shell
 /// clawless generate command my-command
 /// ```
-#[command(noop = true, alias = "g")]
+#[command(require_subcommand, alias = "g")]
 pub async fn generate(_args: GenerateArgs, _context: Context) -> CommandResult {
     Ok(())
 }

--- a/crates/clawless-derive/src/command.rs
+++ b/crates/clawless-derive/src/command.rs
@@ -14,8 +14,9 @@ pub struct CommandGenerator {
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, FromMeta, Default)]
 struct Attributes {
+    /// Require a subcommand; show help if invoked without one
     #[darling(default)]
-    noop: bool,
+    require_subcommand: bool,
     #[darling(default)]
     root: bool,
     #[darling(default, multiple)]
@@ -113,7 +114,7 @@ impl CommandGenerator {
             };
         }
 
-        if self.attrs.noop {
+        if self.attrs.require_subcommand {
             command = quote! {
                 #command.arg_required_else_help(true)
             };
@@ -207,9 +208,9 @@ mod tests {
         CommandGenerator::new(TokenStream::new(), input_function)
     }
 
-    fn generator_with_args_and_noop() -> CommandGenerator {
+    fn generator_with_require_subcommand() -> CommandGenerator {
         let attrs = quote! {
-            noop = true
+            require_subcommand
         };
 
         let input = quote! {
@@ -259,9 +260,9 @@ mod tests {
         CommandGenerator::new(attrs, input_function)
     }
 
-    fn generator_with_noop_and_alias() -> CommandGenerator {
+    fn generator_with_require_subcommand_and_alias() -> CommandGenerator {
         let attrs = quote! {
-            noop = true, alias = "f"
+            require_subcommand, alias = "f"
         };
 
         let input = quote! {
@@ -364,8 +365,8 @@ mod tests {
     }
 
     #[test]
-    fn command_new_with_args_and_noop() {
-        let generator = generator_with_args_and_noop();
+    fn command_new_with_require_subcommand() {
+        let generator = generator_with_require_subcommand();
 
         let actual = generator.command_new();
         let expected = quote! {
@@ -414,8 +415,8 @@ mod tests {
     }
 
     #[test]
-    fn command_new_with_noop_and_alias() {
-        let generator = generator_with_noop_and_alias();
+    fn command_new_with_require_subcommand_and_alias() {
+        let generator = generator_with_require_subcommand_and_alias();
 
         let actual = generator.command_new();
         let expected = quote! {

--- a/crates/clawless-derive/src/lib.rs
+++ b/crates/clawless-derive/src/lib.rs
@@ -33,7 +33,7 @@ pub fn commands(_input: TokenStream) -> TokenStream {
         #[derive(Debug, clawless::clap::Args)]
         struct ClawlessEntryPoint {}
 
-        #[clawless::command(noop = true, root = true)]
+        #[clawless::command(require_subcommand, root = true)]
         async fn clawless(_args: ClawlessEntryPoint, _context: clawless::context::Context) -> clawless::CommandResult {
             Ok(())
         }
@@ -86,7 +86,16 @@ pub fn main(_input: TokenStream) -> TokenStream {
 /// # Attributes
 ///
 /// - `alias = "name"` - Add a visible alias for the command. Can be repeated for multiple aliases.
-/// - `noop = true` - Mark the command as a group that requires a subcommand (no action on its own).
+/// - `require_subcommand` - Require a subcommand; show help if the command is invoked without one.
+///
+/// # Requiring Subcommands
+///
+/// Use `require_subcommand` to create a command that serves as a container for subcommands. When
+/// this attribute is set, invoking the command without a subcommand will display help instead of
+/// running the command body. This is useful for organizing related commands under a common prefix.
+///
+/// For example, a CLI might have `db migrate`, `db seed`, and `db reset` commands, where `db`
+/// itself requires a subcommand and doesn't perform any action on its own.
 ///
 /// # Examples
 ///
@@ -108,7 +117,7 @@ pub fn main(_input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// Command with aliases:
+/// Command with alias:
 ///
 /// ```rust,ignore
 /// use clawless::prelude::*;
@@ -123,7 +132,7 @@ pub fn main(_input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// Command group with alias:
+/// Command that requires a subcommand:
 ///
 /// ```rust,ignore
 /// use clawless::prelude::*;
@@ -131,8 +140,8 @@ pub fn main(_input: TokenStream) -> TokenStream {
 /// #[derive(Debug, Args)]
 /// pub struct DbArgs {}
 ///
-/// // Users can run `mycli db migrate` or `mycli d migrate`
-/// #[command(noop = true, alias = "d")]
+/// // Running `mycli db` shows help; users must specify a subcommand like `mycli db migrate`
+/// #[command(require_subcommand, alias = "d")]
 /// pub async fn db(args: DbArgs, context: Context) -> CommandResult {
 ///     Ok(())
 /// }


### PR DESCRIPTION
The `noop` attribute for the `#[command]` macro was neither well documented nor well named. Both have been fixed. The attribute has been renamed to `require_subcommand`, which better describes its purpose. If the argument is added, the command function will never be executed and instead passing in a subcommand is mandatory.