### PR TITLE
Use message macro in landing page code example

### DIFF
--- a/docs/src/pages/index.md
+++ b/docs/src/pages/index.md
@@ -24,7 +24,7 @@ pub struct GreetArgs {
 /// Greet the user
 #[command]
 pub async fn greet(args: GreetArgs, context: Context) -> CommandResult {
-    println!("Hello, {}!", args.name);
+    message!("Hello, {}!", args.name);
     Ok(())
 }
 ```


### PR DESCRIPTION
The landing page example used `println!` directly, which contradicts
the output system introduced in the presenter project. This commit
updates the example to use the `message!` macro, matching the pattern
shown in the rest of the documentation.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
