### PR TITLE
Update docs to use cargo-clawless

### DIFF
--- a/docs/docs/concepts/index.md
+++ b/docs/docs/concepts/index.md
@@ -77,7 +77,7 @@ fatigue of choosing and configuring dependencies.
 ### Rapid development
 
 Clawless optimizes for speed of development. The scaffolding CLI (
-`clawless new`, `clawless generate command`) gets you from idea to working code
+`cargo clawless new`, `cargo clawless generate command`) gets you from idea to working code
 quickly.
 
 ### Progressive disclosure

--- a/docs/docs/how-to/generate-commands.md
+++ b/docs/docs/how-to/generate-commands.md
@@ -4,15 +4,15 @@ sidebar_position: 0
 
 # Generate Commands
 
-Use the Clawless CLI to quickly generate new commands without manually creating
-files and updating module declarations.
+Use the scaffolding tool to quickly generate new commands without manually
+creating files and updating module declarations.
 
 ## Prerequisites
 
-Install the Clawless CLI if you haven't already:
+Install the scaffolding tool if you haven't already:
 
 ```bash
-cargo install clawless-cli
+cargo install cargo-clawless
 ```
 
 ## Generate a top-level command
@@ -20,13 +20,13 @@ cargo install clawless-cli
 To create a new command at the top level of your CLI:
 
 ```bash
-clawless generate command <name>
+cargo clawless generate command <name>
 ```
 
 For example, to add a `version` command:
 
 ```bash
-clawless generate command version
+cargo clawless generate command version
 ```
 
 This creates `src/commands/version.rs` with boilerplate code:
@@ -82,7 +82,7 @@ then the nested command.
 ### Step 1: Create the parent command
 
 ```bash
-clawless generate command db
+cargo clawless generate command db
 ```
 
 This creates `src/commands/db.rs`:
@@ -104,7 +104,7 @@ pub async fn db(args: DbArgs, context: Context) -> CommandResult {
 Now you can create a subcommand using a path with `/`:
 
 ```bash
-clawless generate command db/migrate
+cargo clawless generate command db/migrate
 ```
 
 This creates `src/commands/db/migrate.rs` and updates the parent module.
@@ -160,8 +160,8 @@ cargo run -- db migrate
 Generate additional commands in the same group:
 
 ```bash
-clawless generate command db/seed
-clawless generate command db/reset
+cargo clawless generate command db/seed
+cargo clawless generate command db/reset
 ```
 
 These are automatically added as submodules in `src/commands/db.rs`:
@@ -189,12 +189,12 @@ hierarchy:
 
 ```bash
 # Create parent commands first
-clawless generate command config
-clawless generate command config/auth
+cargo clawless generate command config
+cargo clawless generate command config/auth
 
 # Now create the nested commands
-clawless generate command config/auth/login
-clawless generate command config/auth/logout
+cargo clawless generate command config/auth/login
+cargo clawless generate command config/auth/logout
 ```
 
 This creates:
@@ -221,7 +221,7 @@ The generator follows Rust naming conventions:
 Example:
 
 ```bash
-clawless generate command deploy_staging
+cargo clawless generate command deploy_staging
 ```
 
 Creates `src/commands/deploy_staging.rs` with a `deploy_staging()` function that

--- a/docs/docs/how-to/require-subcommands.md
+++ b/docs/docs/how-to/require-subcommands.md
@@ -131,7 +131,7 @@ pub async fn db(args: DbArgs, context: Context) -> CommandResult {
 ```
 
 However, `Ok(())` is the conventional approach and matches the generated code
-from `clawless generate command`.
+from `cargo clawless generate command`.
 
 ## See also
 

--- a/docs/docs/manual-setup.md
+++ b/docs/docs/manual-setup.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Manual Setup
 
-This guide shows how to set up Clawless manually without using the `clawless-cli`
+This guide shows how to set up Clawless manually without using the `cargo-clawless`
 scaffolding tool. This is useful if you want to add Clawless to an existing
 project or prefer to understand the setup process.
 

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -18,7 +18,7 @@ You'll need:
 The Clawless CLI provides scaffolding and code generation for your projects:
 
 ```bash
-cargo install clawless-cli
+cargo install cargo-clawless
 ```
 
 :::tip[Prefer manual setup?]
@@ -31,7 +31,7 @@ yourself, see the [Manual Setup](./manual-setup) guide.
 Generate a new CLI application:
 
 ```bash
-clawless new my-cli
+cargo clawless new my-cli
 cd my-cli
 ```
 
@@ -80,7 +80,7 @@ cargo run -- greet --help
 Generate a new command:
 
 ```bash
-clawless generate command goodbye
+cargo clawless generate command goodbye
 ```
 
 This creates `src/commands/goodbye.rs` and updates the module declarations
@@ -137,8 +137,8 @@ Goodbye, Rust!
 For larger CLIs, organize commands into groups using nested modules:
 
 ```bash
-clawless generate command db/migrate
-clawless generate command db/seed
+cargo clawless generate command db/migrate
+cargo clawless generate command db/seed
 ```
 
 This creates:

--- a/docs/src/pages/index.md
+++ b/docs/src/pages/index.md
@@ -53,8 +53,8 @@ full-featured CLI with production-ready infrastructure.
   directory, etc.) automatically
 - **Async runtime** - Tokio runtime managed for you; just write `async fn` and
   it works
-- **Scaffolding tools** - Generate projects and commands with `clawless new` and
-  `clawless generate command`
+- **Scaffolding tools** - Generate projects and commands with
+  `cargo clawless new` and `cargo clawless generate command`
 - **Convention-based structure** - File hierarchy becomes command hierarchy; no
   manual registration
 - **Type-safe arguments** - Full compiler guarantees for your CLI arguments and


### PR DESCRIPTION
The scaffolding binary was renamed from `clawless-cli` to `cargo-clawless` in #360, making it a proper cargo subcommand invoked as `cargo clawless`. This commit updates all install instructions and CLI invocations across the documentation to reflect the rename.

The blog post is left unchanged as a historical record.