### PR TITLE
Soften tentative language in context and subcommands docs

### DIFF
--- a/docs/docs/concepts/context.md
+++ b/docs/docs/concepts/context.md
@@ -10,10 +10,10 @@ batteries-included functionality to your commands without requiring manual
 setup.
 
 :::info[Growing incrementally]
-The Context system is evolving. Currently, it provides access to the working
-directory, [cancellation](./cancellation), and [output](./output). Features
-described in the [Future features](#future-features) section (configuration,
-structured logging) are planned but not yet implemented.
+Context currently provides access to the working directory,
+[cancellation](./cancellation), and [output](./output). Additional features
+like configuration and structured logging are planned — see
+[future features](#future-features) below.
 :::
 
 ## What is Context?

--- a/docs/docs/how-to/require-subcommands.md
+++ b/docs/docs/how-to/require-subcommands.md
@@ -7,11 +7,10 @@ sidebar_position: 2
 Prevent a command from executing without a subcommand, automatically showing
 help instead.
 
-:::info[Future API Changes]
-The `require_subcommand` attribute and the need for empty command group
-functions are temporary implementation details. A future release will likely
-introduce a dedicated command group macro to make this pattern cleaner and more
-explicit. The current API works but may change.
+:::info[Future API changes]
+A future release may introduce a dedicated command group macro to make this
+pattern more explicit. The current `require_subcommand` attribute works well
+but the API may evolve.
 :::
 
 ## When to use this


### PR DESCRIPTION
The context info box described the system as "evolving" and the require-subcommands note called the attribute a "temporary implementation detail." Both are overly tentative for stable, shipped features. This commit tightens the wording to be factual without implying instability.