### PR TITLE
Replace action that installs just

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Just
-        uses: taiki-e/install-action@7769b73c2ec98c38dfcf2e18c83cfd4880c038c1 # v2.75.27
-        with:
-          tool: just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # 4.0.0
 
       - name: Export targets
         id: export-targets


### PR DESCRIPTION
We used the `taiki-e/install-action` to install just in CI, but due to the nature of the action its SHA changed repeatedly. This caused Renovate to open many pull requests against this repository, burning through valuable GitHub Actions minutes.

We are switching to another action that only installs just, but because of that doesn't change as frequently.