### PR TITLE
Run the pre-commit formatters before the checks

### DIFF
--- a/justfile
+++ b/justfile
@@ -9,11 +9,21 @@ default:
     @just --list
 
 # Run a subset of checks as pre-commit hooks
-pre-commit:
-    #!/usr/bin/env -S parallel --shebang --ungroup --jobs {{ num_cpus() }}
+pre-commit: pre-commit-fix pre-commit-verify
+
+# Every recipe that rewrites the working tree, in sequence: they overlap each
+# other, and nothing may read a file while one of them is writing it.
+[private]
+pre-commit-fix:
     just prettier true
     just format-toml true
     just format-rust true
+
+# Every recipe that only reads, in parallel: the tree has stopped changing, so
+# what each of them sees is what the commit will contain.
+[private]
+pre-commit-verify:
+    #!/usr/bin/env -S flox activate -- parallel --shebang --ungroup --jobs {{ num_cpus() }}
     just lint-github-actions
     just lint-markdown
     just lint-rust


### PR DESCRIPTION
The pre-commit recipe ran everything at once: three formatters that
rewrite the working tree, alongside four linters and the test suite
that read it. Nothing kept `just format-rust true` from rewriting a
file while `just lint-rust` was compiling it, so a run could see a mix
of formatted and unformatted sources, and its verdict depended on which
recipe reached a file first.

The recipe is now two phases. The formatters run in sequence, because
they overlap each other as well. The read-only recipes then run in
parallel, once the tree has stopped changing, so that what each of them
sees is what the commit will contain. Both phases are private, which
keeps the list of recipes that CI derives from `just --list` unchanged.

The shebang that starts parallel now activates the Flox environment as
well. A shebang recipe bypasses the `shell` setting at the top of the
justfile, so this recipe never ran inside the environment the way every
other recipe does, and it failed with `env: parallel: No such file or
directory` for anyone whose shell was not already activated. That
included the pre-commit hook itself, which pre-commit runs as a system
command. An already activated shell pays nothing for it, because Flox
short-circuits a nested activation.

