### PR TITLE
Lint every Markdown file in the repository

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,12 @@
 ---
+# Long lines inside a code block cannot always wrap: a shell command, a
+# directory tree, or a message meant to be copied verbatim has to stay on one
+# line. Prose still wraps at 80.
 MD013:
+  code_blocks: false
   tables: false
+
+# The same heading may appear under two different parents, e.g. "SIGTERM
+# behavior" under both a design and an alternatives section.
+MD024:
+  siblings_only: true

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,6 @@
+.claude/
+.flox/
+CLAUDE.md
+docs/build/
+docs/node_modules/
+target/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
+<!-- markdownlint-disable MD033 MD041 -->
+
 <div style="text-align:center">
-    <img src="docs/static/img/logo.svg" height="200" />
+    <img src="docs/static/img/logo.svg" alt="Clawless logo" height="200" />
 </div>
+
+<!-- markdownlint-enable MD033 MD041 -->
 
 # 🦦 Clawless
 

--- a/docs/blog/2025-12-19-public-release.md
+++ b/docs/blog/2025-12-19-public-release.md
@@ -52,7 +52,7 @@ command structure**.
 
 Want to add a `db migrate` subcommand? Create this structure:
 
-```
+```text
 src/
 ├── main.rs
 ├── commands.rs

--- a/docs/docs/concepts/arguments.md
+++ b/docs/docs/concepts/arguments.md
@@ -148,7 +148,7 @@ pub struct DeployArgs {
 
 Running `myapp deploy --help` shows:
 
-```
+```text
 Arguments:
   <ENVIRONMENT>  The environment to deploy to.
 

--- a/docs/docs/concepts/commands.md
+++ b/docs/docs/concepts/commands.md
@@ -130,7 +130,7 @@ pub async fn read_file(args: ReadArgs, context: Context) -> CommandResult {
 
 If the file doesn't exist, users see:
 
-```
+```text
 Error: No such file or directory (os error 2)
 ```
 
@@ -156,7 +156,7 @@ pub async fn read_config(args: ReadArgs, context: Context) -> CommandResult {
 
 Now errors include context:
 
-```
+```text
 Error: Failed to parse TOML configuration
 
 Caused by:

--- a/docs/docs/concepts/index.md
+++ b/docs/docs/concepts/index.md
@@ -82,9 +82,9 @@ fatigue of choosing and configuring dependencies.
 
 ### Rapid development
 
-Clawless optimizes for speed of development. The scaffolding CLI (
-`cargo clawless new`, `cargo clawless generate command`) gets you from idea to working code
-quickly.
+Clawless optimizes for speed of development. The scaffolding CLI
+(`cargo clawless new`, `cargo clawless generate command`) gets you from idea to
+working code quickly.
 
 ### Progressive disclosure
 

--- a/docs/docs/concepts/macros.md
+++ b/docs/docs/concepts/macros.md
@@ -187,7 +187,7 @@ than a format string.
 
 Here's the flow when your CLI runs:
 
-```
+```text
 1. User runs: myapp greet World
 
 2. main!() generates main():

--- a/docs/docs/concepts/naming-conventions.md
+++ b/docs/docs/concepts/naming-conventions.md
@@ -65,7 +65,7 @@ Directory names become subcommand groups:
 
 Example structure:
 
-```
+```text
 src/commands/
 ├── db.rs (contains: pub async fn db(...))
 └── db/
@@ -122,7 +122,7 @@ pub async fn greet(args: GreetArgs, context: Context) -> CommandResult {
 
 Running `myapp greet --help` shows:
 
-```
+```text
 Greet the user by name
 
 This command prints a friendly greeting message.

--- a/docs/docs/concepts/project-structure.md
+++ b/docs/docs/concepts/project-structure.md
@@ -4,13 +4,15 @@ sidebar_position: 7
 
 # Project Structure
 
-In Clawless, your file structure directly maps to your command structure. This convention makes your CLI's organization immediately clear from the codebase layout.
+In Clawless, your file structure directly maps to your command structure. This
+convention makes your CLI's organization immediately clear from the codebase
+layout.
 
 ## The basic structure
 
 Every Clawless project follows this structure:
 
-```
+```text
 myapp/
 ├── src/
 │   ├── main.rs          # Application entry point
@@ -33,7 +35,7 @@ The convention is simple: **module hierarchy becomes subcommand hierarchy**.
 
 ### Single-level commands
 
-```
+```text
 src/
 ├── main.rs
 ├── commands.rs
@@ -55,7 +57,7 @@ Each file contains one command function marked with `#[command]`.
 
 ### Nested commands (subcommands)
 
-```
+```text
 src/
 ├── main.rs
 ├── commands.rs
@@ -77,11 +79,12 @@ myapp db seed
 myapp db reset
 ```
 
-The `db/` directory becomes a command group. Commands inside it become subcommands of `db`.
+The `db/` directory becomes a command group. Commands inside it become
+subcommands of `db`.
 
 ### Multi-level nesting
 
-```
+```text
 src/
 ├── main.rs
 ├── commands.rs
@@ -115,7 +118,8 @@ Nesting can go as deep as needed, though more than 2-3 levels is rare in practic
 
 ## Command group functions
 
-When you have a nested directory like `db/`, you must create a command function in `db.rs`:
+When you have a nested directory like `db/`, you must create a command function
+in `db.rs`:
 
 ```rust
 // src/commands/db.rs
@@ -136,7 +140,8 @@ pub async fn db(_args: DbArgs, context: Context) -> CommandResult {
 }
 ```
 
-Optionally, add `require_subcommand` to skip executing the function and show help instead:
+Optionally, add `require_subcommand` to skip executing the function and show
+help instead:
 
 ```rust
 /// Database management commands
@@ -147,13 +152,14 @@ pub async fn db(_args: DbArgs, context: Context) -> CommandResult {
 }
 ```
 
-With `require_subcommand`, running `myapp db` shows help for the db subcommands. Without it, the function executes.
+With `require_subcommand`, running `myapp db` shows help for the db subcommands.
+Without it, the function executes.
 
 ## Organizing large CLIs
 
 As your CLI grows, organize related commands into logical groups:
 
-```
+```text
 src/
 ├── main.rs
 ├── commands.rs
@@ -192,7 +198,9 @@ myapp user create
 
 ## Naming
 
-Follow Rust's standard naming conventions (snake_case for files, directories, and functions). Clawless automatically converts snake_case to kebab-case for CLI commands:
+Follow Rust's standard naming conventions (snake_case for files, directories,
+and functions). Clawless automatically converts snake_case to kebab-case for CLI
+commands:
 
 - `deploy_staging.rs` → `myapp deploy-staging`
 - `user_management.rs` → `myapp user-management`
@@ -204,7 +212,7 @@ See [Naming Conventions](./naming-conventions) for details.
 
 ### Simple CLI
 
-```
+```text
 src/
 ├── main.rs
 ├── commands.rs
@@ -218,7 +226,7 @@ Commands: `myapp init`, `myapp build`, `myapp test`
 
 ### Medium CLI with grouping
 
-```
+```text
 src/
 ├── main.rs
 ├── commands.rs
@@ -234,11 +242,12 @@ src/
         └── remove.rs
 ```
 
-Commands: `myapp init`, `myapp config get`, `myapp config set`, `myapp plugin install`, `myapp plugin remove`
+Commands: `myapp init`, `myapp config get`, `myapp config set`, `myapp plugin
+install`, `myapp plugin remove`
 
 ### Large CLI with deep nesting
 
-```
+```text
 src/
 ├── main.rs
 ├── commands.rs
@@ -265,12 +274,14 @@ src/
         └── logout.rs
 ```
 
-Commands: `myapp project create`, `myapp project settings show`, `myapp deployment logs view`, etc.
+Commands: `myapp project create`, `myapp project settings show`, `myapp
+deployment logs view`, etc.
 
 ## What's next
 
 Now that you understand project structure, learn about:
 
-- **[Naming Conventions](./naming-conventions)** - How file and function names become command names
+- **[Naming Conventions](./naming-conventions)** - How file and function names
+  become command names
 - **[Commands](./commands)** - How to write command functions
 - **[Macros](./macros)** - How the structure is wired together

--- a/docs/docs/how-to/organize-large-cli.md
+++ b/docs/docs/how-to/organize-large-cli.md
@@ -36,7 +36,7 @@ pub async fn deploy(args: DeployArgs, context: Context) -> CommandResult {
 
 Create modules outside `src/commands/` for your actual application logic:
 
-```
+```text
 src/
 ├── main.rs
 ├── commands.rs
@@ -80,7 +80,7 @@ This separation means:
 
 As you add commands, group related ones together using nested modules:
 
-```
+```text
 src/commands/
 ├── build.rs
 ├── test.rs
@@ -119,7 +119,7 @@ pub async fn get(args: GetArgs, context: Context) -> CommandResult {
 
 A deployment tool with multiple domains:
 
-```
+```text
 src/
 ├── main.rs
 ├── commands.rs
@@ -176,7 +176,7 @@ pub async fn create(args: CreateArgs, context: Context) -> CommandResult {
 If you need to share code between commands in the same group, create a
 non-command module:
 
-```
+```text
 src/commands/
 ├── database.rs
 └── database/

--- a/docs/docs/how-to/test-with-trycmd.md
+++ b/docs/docs/how-to/test-with-trycmd.md
@@ -62,7 +62,7 @@ status.code = 0
 
 `tests/cmd/greet.stdout`:
 
-```
+```text
 Hello, World!
 ```
 
@@ -72,7 +72,7 @@ The test passes if the command's stdout matches the file exactly.
 
 For commands that create or modify files, use `.in/` and `.out/` directories:
 
-```
+```text
 tests/cmd/
 ├── init.toml
 ├── init.in/
@@ -115,7 +115,7 @@ status.code = 2
 
 `tests/cmd/missing-arg.stderr`:
 
-```
+```text
 error: the following required arguments were not provided:
   <ENVIRONMENT>
 ...
@@ -138,7 +138,7 @@ Review the changes before committing.
 
 A typical test setup looks like this:
 
-```
+```text
 my-cli/
 ├── src/
 │   ├── main.rs

--- a/docs/docs/manual-setup.md
+++ b/docs/docs/manual-setup.md
@@ -99,7 +99,7 @@ cargo run -- --help
 
 Your project should look like this:
 
-```
+```text
 my-cli/
 ├── Cargo.toml
 └── src/

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -52,7 +52,7 @@ cargo run -- greet
 
 Output:
 
-```
+```text
 Hello, World!
 ```
 
@@ -64,7 +64,7 @@ cargo run -- greet Rust
 
 Output:
 
-```
+```text
 Hello, Rust!
 ```
 
@@ -128,7 +128,7 @@ cargo run -- goodbye Rust
 
 Output:
 
-```
+```text
 Goodbye, Rust!
 ```
 
@@ -143,7 +143,7 @@ cargo clawless generate command db/seed
 
 This creates:
 
-```
+```text
 src/commands/
 ├── greet.rs
 ├── goodbye.rs

--- a/docs/src/pages/index.md
+++ b/docs/src/pages/index.md
@@ -1,4 +1,8 @@
+<!-- markdownlint-disable MD033 MD041 -->
+
 <img src="/img/logo.svg" alt="Clawless Logo" width="200"/>
+
+<!-- markdownlint-enable MD033 MD041 -->
 
 # Clawless
 
@@ -85,7 +89,7 @@ Clawless uses conventions and code generation to build your CLI:
 1. **File structure = Command structure** - Your module hierarchy maps directly
    to CLI commands:
 
-   ```
+   ```text
    src/commands/db/migrate.rs  →  myapp db migrate
    ```
 

--- a/justfile
+++ b/justfile
@@ -137,8 +137,12 @@ lint-github-actions:
     zizmor -p .
 
 # Lint Markdown files
+#
+# The glob is quoted so that markdownlint expands it. The recipe shell is
+# `sh`, which has no globstar, so an unquoted `**/*.md` collapses to
+# `*/*.md` and reaches only the files one directory deep.
 lint-markdown:
-    markdownlint --ignore-path .gitignore **/*.md
+    markdownlint "**/*.md"
 
 # Lint Rust files
 lint-rust:

--- a/specs/features/005-command-output.md
+++ b/specs/features/005-command-output.md
@@ -294,7 +294,6 @@ so any trycmd fixtures that assert on help output will need updating.
 None. All design decisions for this feature have been resolved.
 
 [application]: ../architecture.md#application
-[architecture]: ../architecture.md
 [cancellation-integration]: 003-command-cancellation.md
 [context]: ../architecture.md#context
 [output-types]: 004-output-types.md

--- a/specs/features/006-event-types.md
+++ b/specs/features/006-event-types.md
@@ -97,9 +97,11 @@ is implemented.
 2. `Event::Message` carries a `String` payload.
 3. `Event::Detail` carries a `String` payload.
 4. `Event::Artifact` carries a `Box<dyn Artifact>`.
-5. `Artifact` is a trait combining `Display + erased_serde::Serialize + Debug + Send + Sync`.
+5. `Artifact` is a trait combining `Display + erased_serde::Serialize + Debug +
+Send + Sync`.
 6. A blanket impl covers any `T: Display + Serialize + Debug + Send + Sync + 'static`.
-7. `Event` implements `Debug` (manually, delegating to the `Debug` bound on `Artifact` for the trait object variant).
+7. `Event` implements `Debug` (manually, delegating to the `Debug` bound on
+   `Artifact` for the trait object variant).
 8. `Event` does not implement `Clone`.
 9. `Event` is `Send + Sync`.
 10. Types are defined in `crates/clawless/src/event.rs`.

--- a/specs/features/007-event-channel.md
+++ b/specs/features/007-event-channel.md
@@ -56,7 +56,8 @@ without changing the public API.
 4. The channel is bounded with a reasonable default capacity (e.g., 256).
 5. `EventSender` is `Clone + Send + Sync`.
 6. `EventReceiver` is `Send`.
-7. `SendError` is a struct wrapping the unsent `Event`, returned when the receiver has been dropped.
+7. `SendError` is a struct wrapping the unsent `Event`, returned when the
+   receiver has been dropped.
 8. `SendError` implements `Debug`, `Display`, and `Error`.
 9. When all senders are dropped, `recv()` returns `None` (channel closed).
 10. Types are defined in `crates/clawless/src/event_channel.rs`.

--- a/specs/features/009-presenter-rendering.md
+++ b/specs/features/009-presenter-rendering.md
@@ -139,7 +139,6 @@ None. All design decisions for this feature have been resolved.
 [architecture]: ../architecture.md
 [event-channel]: 007-event-channel.md
 [event-types]: 006-event-types.md
-[output]: ../../crates/clawless/src/output.rs
 [output-events]: 011-output-events.md
 [presenter]: 008-presenter.md
 [presenter-macros]: 010-presenter-macros.md

--- a/specs/features/010-presenter-macros.md
+++ b/specs/features/010-presenter-macros.md
@@ -158,11 +158,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 None. All design decisions for this feature have been resolved.
 
-[architecture]: ../architecture.md
-[event-channel]: 007-event-channel.md
 [output]: ../../crates/clawless/src/output.rs
 [output-events]: 011-output-events.md
 [presenter]: 008-presenter.md
-[presenter-macros]: 010-presenter-macros.md
 [presenter-rendering]: 009-presenter-rendering.md
 [project]: ../projects/003-presenter.md

--- a/specs/features/011-output-events.md
+++ b/specs/features/011-output-events.md
@@ -192,7 +192,6 @@ impl Output {
 
 None. All design decisions for this feature have been resolved.
 
-[architecture]: ../architecture.md
 [event-channel]: 007-event-channel.md
 [event-types]: 006-event-types.md
 [output]: ../../crates/clawless/src/output.rs


### PR DESCRIPTION
The lint-markdown recipe passed `**/*.md` to markdownlint unquoted. The recipe shell is `sh`, which has no globstar, so the pattern collapsed to `*/*.md` and reached only the files exactly one directory deep: eight of the fifty-five Markdown files we keep. The README, the agent instructions, the documentation site, and every feature spec went unchecked. Quoting the glob hands the expansion to markdownlint, which does understand it, and a `.markdownlintignore` keeps the tool out of the directories that `--ignore-path .gitignore` used to exclude.

The wider net caught sixty-four problems. Twenty-nine fenced code blocks carried no language and are directory trees or command output, so they are `text` now. Thirteen prose lines ran past eighty characters and are rewrapped. Six link reference definitions were never referenced and are gone, and the logo in the README gained the alt text it was missing.

Ten of the sixty-four were the rules being wrong rather than the files. A line inside a code block cannot always wrap, because a command or a tree has to survive a copy, so the line limit no longer applies there. The same heading may legitimately appear under two different parents, so duplicates are only compared among siblings. The HTML logo headers in the README and on the landing page are deliberate, and each one disables the two rules it breaks in place.
