### PR TITLE
Refresh crate READMEs and metadata for 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 # 🦦 Clawless
 
 Clawless is a batteries-included framework that provides everything you need for
-production CLIs: structured output, configuration management, environment
-context, and scaffolding tools. You write command functions; Clawless provides
-the infrastructure.
+production CLIs: structured output, environment context, graceful cancellation,
+and scaffolding tools. You write command functions; Clawless provides the
+infrastructure.
 
 ```rust
 use clawless::prelude::*;
@@ -26,51 +26,51 @@ pub struct GreetArgs {
 /// Greet the user
 #[command]
 pub async fn greet(args: GreetArgs, context: Context) -> CommandResult {
-    println!("Hello, {}!", args.name);
+    message!("Hello, {}!", args.name);
     Ok(())
 }
 ```
 
-That's it. The function name becomes your command name, doc comments become help
-text, and the `Context` parameter gives you access to environment info,
-configuration, and output abstractions. Everything you need to build a
-professional CLI is already there.
+That's it. The function name becomes your command name, and doc comments become
+help text. The `message!` macro sends output through the Clawless output
+system. Users can pass `--quiet`, `--verbose`, or `--json` to control the
+output of any command, without changes to the command itself.
 
 ## Quick Start
 
-Install the Clawless CLI:
+Install the scaffolding tool:
 
 ```bash
-cargo install clawless-cli
+cargo install cargo-clawless
 ```
 
 Create a new project:
 
 ```bash
-clawless new my-cli
+cargo clawless new my-cli
 cd my-cli
 cargo run -- greet
 ```
 
-Read the [Quick Start guide](https://clawless.rs/docs/quick-start) for a
-complete walkthrough.
+Read the [Quick Start guide][quick-start] for a complete walkthrough.
 
 ## Features
 
 - **Convention over configuration** - File hierarchy maps to command hierarchy
 - **Type-safe arguments** - Full compiler guarantees via Clap's derive API
 - **Async by default** - Tokio runtime managed automatically
-- **Context system** - Access environment info and framework features
-- **Scaffolding tools** - Generate projects and commands with `clawless new` and
-  `clawless generate`
+- **Structured output** - `message!`, `detail!`, and `artifact!` render as text
+  or JSON, controlled by the `--quiet`, `--verbose`, and `--json` flags
+- **Graceful cancellation** - Cooperative shutdown with `Cancellation` tokens
+- **Scaffolding tools** - Generate projects and commands with
+  `cargo clawless new` and `cargo clawless generate command`
 - **Doc-driven help** - Doc comments become help text
 
 ## Documentation
 
-- **[clawless.rs](https://clawless.rs)** - Full documentation and guides
-- **[docs.rs/clawless](https://docs.rs/clawless)** - API reference
-- **[crates.io/crates/clawless](https://crates.io/crates/clawless)** - Published
-  crate
+- **[clawless.rs][docs]** - Full documentation and guides
+- **[docs.rs/clawless][docs-rs]** - API reference
+- **[crates.io/crates/clawless][crates-io]** - Published crate
 
 ## Project Status
 
@@ -78,12 +78,11 @@ Clawless is actively used in our internal projects and continues to evolve based
 on real-world needs. The core concepts are stable, but we will add new features
 and refine APIs as we expand its capabilities.
 
-Check out the [roadmap](https://github.com/aonyx-ai/clawless/issues) to see what
-we're working on and share your ideas.
+Check out the [roadmap][issues] to see what we're working on and share your
+ideas.
 
 If you're building internal tools or prototyping, Clawless is a great choice.
-For production applications, review
-the [open issues](https://github.com/aonyx-ai/clawless/issues) to understand
+For production applications, review the [open issues][issues] to understand
 current limitations and upcoming features.
 
 ## License
@@ -102,3 +101,9 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
+
+[crates-io]: https://crates.io/crates/clawless
+[docs]: https://clawless.rs
+[docs-rs]: https://docs.rs/clawless
+[issues]: https://github.com/aonyx-ai/clawless/issues
+[quick-start]: https://clawless.rs/docs/quick-start

--- a/crates/clawless-cli/Cargo.toml
+++ b/crates/clawless-cli/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+categories = ["command-line-interface"]
+keywords = ["cli", "framework"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/clawless-cli/README.md
+++ b/crates/clawless-cli/README.md
@@ -1,0 +1,47 @@
+# 🦦 clawless-cli
+
+`clawless` is an opinionated, batteries-included framework for building
+command-line applications with Rust. It features low-level building blocks and
+high-level abstractions that can be used to build stateless CLIs or stateful
+TUI applications.
+
+This crate, `clawless-cli`, implements the CLI presentation layer of the
+framework. It contains the command execution context, the output
+configuration, and the push-based presenter that renders command output to the
+terminal as events arrive.
+
+Use the [`clawless`] facade crate instead of this crate. The facade re-exports
+everything from this crate alongside [`clawless-core`] and
+[`clawless-derive`], so that CLI applications need only a single dependency.
+
+## History
+
+Before version 0.6.0, `clawless-cli` was the scaffolding tool for the
+framework, and `cargo install clawless-cli` installed the `clawless` binary.
+The scaffolding tool is now in [`cargo-clawless`], and this crate no longer
+contains a binary. To scaffold projects and generate commands, install the new
+crate instead:
+
+```shell
+cargo install cargo-clawless
+```
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 (<http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license (<http://opensource.org/licenses/MIT>)
+
+at your option.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[`cargo-clawless`]: https://crates.io/crates/cargo-clawless
+[`clawless`]: https://docs.rs/clawless
+[`clawless-core`]: https://docs.rs/clawless-core
+[`clawless-derive`]: https://docs.rs/clawless-derive

--- a/crates/clawless-cli/src/lib.rs
+++ b/crates/clawless-cli/src/lib.rs
@@ -1,16 +1,4 @@
-//! CLI presentation layer for the Clawless framework
-//!
-//! This crate provides the CLI-specific types and traits for building command-line applications
-//! with Clawless. It includes the command execution context, output configuration, and the
-//! presenter abstraction for rendering command output to the terminal.
-//!
-//! Most users should depend on the [`clawless`] facade crate instead of using this crate directly.
-//! The facade re-exports everything from this crate alongside [`clawless-core`] and
-//! [`clawless-derive`], providing a single dependency for CLI applications.
-//!
-//! [`clawless`]: https://docs.rs/clawless
-//! [`clawless-core`]: https://docs.rs/clawless-core
-//! [`clawless-derive`]: https://docs.rs/clawless-derive
+#![cfg_attr(not(doctest),doc = include_str!("../README.md"))]
 #![warn(missing_docs)]
 
 pub mod error;

--- a/crates/clawless-core/Cargo.toml
+++ b/crates/clawless-core/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+categories = ["command-line-interface"]
+keywords = ["cli", "framework"]
+
 [dependencies]
 bon = { workspace = true }
 erased-serde = { workspace = true }

--- a/crates/clawless-tui/Cargo.toml
+++ b/crates/clawless-tui/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+categories = ["command-line-interface"]
+keywords = ["cli", "framework", "tui"]
+
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }

--- a/crates/clawless/README.md
+++ b/crates/clawless/README.md
@@ -1,22 +1,27 @@
 # 🦦 Clawless
 
-`clawless` is a framework for building command-line applications with Rust. Its
-goal is to provide high-level building blocks and well-designed conventions so
-that users can focus on their applications.
+`clawless` is an opinionated, batteries-included framework for building
+command-line applications with Rust. It features low-level building blocks and
+high-level abstractions that can be used to build stateless CLIs or stateful
+TUI applications.
 
-The library exports a few macros that create a command-line application, parse
-arguments, and then call user-defined functions.
-
-## Project Status
-
-Clawless is in a very early prototyping phase and not considered ready for
-production use. Follow the project and check out the open issues to understand
-the crate's current limitations.
+This crate is the facade of the framework. It re-exports [`clawless-core`],
+[`clawless-cli`], and [`clawless-tui`], along with the macros from
+[`clawless-derive`], so that applications need only a single dependency. The
+full documentation and guides are available at [clawless.rs].
 
 ## Usage
 
-First of all, generate a new binary crate using `cargo new --bin <name>`. Inside
-the crate, open `src/main.rs` and replace the generated contents with the
+The quickest way to create a new project is the scaffolding tool:
+
+```shell
+cargo install cargo-clawless
+cargo clawless new my-cli
+```
+
+To set up a project manually instead, create a new binary crate with
+`cargo new --bin <name>`. Then add `clawless` as a dependency. Inside the
+crate, open `src/main.rs` and replace the generated contents with the
 following snippet:
 
 ```rust,ignore
@@ -25,8 +30,7 @@ mod commands;
 clawless::main!();
 ```
 
-Next, create `src/commands.rs` (or `src/commands/mod.rs`) to set up your
-commands module:
+Next, create `src/commands.rs` to set up your commands module:
 
 ```rust,ignore
 clawless::commands!();
@@ -47,7 +51,7 @@ pub struct GreetArgs {
 
 #[command]
 pub async fn greet(args: GreetArgs, context: Context) -> CommandResult {
-    println!("Hello, {}!", args.name);
+    message!("Hello, {}!", args.name);
     Ok(())
 }
 ```
@@ -74,11 +78,11 @@ module hierarchy naturally maps to subcommand groups:
 ```text
 src/
 ├── main.rs
+├── commands.rs
 └── commands/
-    ├── mod.rs
     ├── greet.rs
+    ├── db.rs
     └── db/
-        ├── mod.rs
         ├── migrate.rs
         └── seed.rs
 ```
@@ -88,6 +92,9 @@ With this structure:
 - `cargo run -- greet` runs the `greet` command
 - `cargo run -- db migrate` runs the `db::migrate` command
 - `cargo run -- db seed` runs the `db::seed` command
+
+Parent modules declare their children, so `src/commands/db.rs` contains
+`mod migrate;` and `mod seed;`.
 
 ## License
 
@@ -103,3 +110,9 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
+
+[clawless.rs]: https://clawless.rs
+[`clawless-cli`]: https://docs.rs/clawless-cli
+[`clawless-core`]: https://docs.rs/clawless-core
+[`clawless-derive`]: https://docs.rs/clawless-derive
+[`clawless-tui`]: https://docs.rs/clawless-tui


### PR DESCRIPTION
The crate READMEs still described the framework as it was before the Presenter rewrite: examples printed with println!, installation pointed at the old clawless-cli binary, and the facade README called the project an early prototype. cargo publish packages each README into its crate, so the stale content would have shipped to crates.io and docs.rs with the 0.6.0 release.

This change updates the root and facade READMEs for the 0.6.0 API, gives clawless-cli its first README, and declares categories and keywords for the three layer crates. The new README documents the change of identity of clawless-cli: the crate was the scaffolding binary before 0.6.0 and is a library now, so `cargo install clawless-cli` stops working, and readers find a pointer to cargo-clawless instead. The crate-level doc comment moves into the README through the same `include_str!` attribute that the sibling crates use.