### PR TITLE
Lint Markdown files in dot-directories

### DIFF
--- a/justfile
+++ b/justfile
@@ -140,9 +140,11 @@ lint-github-actions:
 #
 # The glob is quoted so that markdownlint expands it. The recipe shell is
 # `sh`, which has no globstar, so an unquoted `**/*.md` collapses to
-# `*/*.md` and reaches only the files one directory deep.
+# `*/*.md` and reaches only the files one directory deep. The `--dot` flag
+# extends the glob into dot-directories such as `.github`, which it skips
+# by default; `.markdownlintignore` excludes the ones we do not lint.
 lint-markdown:
-    markdownlint "**/*.md"
+    markdownlint --dot "**/*.md"
 
 # Lint Rust files
 lint-rust:


### PR DESCRIPTION
The lint-markdown recipe quotes its glob so that markdownlint expands `**/*.md` itself, with the goal of reaching every tracked Markdown file. The tool skips files and directories with a leading dot unless it is told otherwise, so the two instruction files under `.github/instructions/` were still never linted. The `.claude/` and `.flox/` entries in `.markdownlintignore` were dead for the same reason: the glob never descended into those directories in the first place.

With this commit, the recipe passes `--dot` to markdownlint, which extends the glob into dot-directories. The ignore file now actually keeps `.claude/` and `.flox/` out of the lint, and the instruction files under `.github/` already pass, so no other changes are needed.