### PR TITLE
Keep the linters out of Claude Code worktrees

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,4 +1,5 @@
 exclude = [
+  ".claude/worktrees/**",
   ".flox/**",
   "crates/cargo-clawless/tests/commands/new.out/cli/Cargo.toml",
 ]

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -2,6 +2,7 @@
 extends: default
 
 ignore: |
+  .claude/worktrees/*
   .flox/cache/*
   docs/node_modules/*
   target/*


### PR DESCRIPTION
Claude Code creates git worktrees under `.claude/worktrees/`, so a checkout can hold complete copies of the repository at other revisions. The linters that walk the file system rather than the git index descend into those copies and report problems in files that belong to another branch, which fails a local pre-commit run for reasons the commit has nothing to do with.

The directory is already in `.gitignore`, and that alone is enough for prettier, which reads `.gitignore` by default, and for markdownlint, which skips all of `.claude/`. Cargo stays inside the workspace members, zizmor reads only the top-level workflow directory, and the pre-commit hooks see only staged files, so none of them can reach an ignored directory. Taplo and yamllint were the two tools left, and both now exclude the worktrees as well.