### PR TITLE
Run doc tests and fix the examples that drifted

### DIFF
--- a/crates/clawless-core/src/cancellation.rs
+++ b/crates/clawless-core/src/cancellation.rs
@@ -24,7 +24,7 @@ pub use tokio_util::sync::WaitForCancellationFuture;
 /// # Examples
 ///
 /// ```
-/// use clawless::prelude::*;
+/// use clawless_core::cancellation::Cancellation;
 ///
 /// let root = Cancellation::new();
 /// let child = root.child();
@@ -57,7 +57,7 @@ impl Cancellation {
     /// # Examples
     ///
     /// ```
-    /// use clawless::prelude::*;
+    /// use clawless_core::cancellation::Cancellation;
     ///
     /// let cancellation = Cancellation::new();
     /// assert!(!cancellation.is_cancelled());
@@ -75,7 +75,7 @@ impl Cancellation {
     /// # Examples
     ///
     /// ```
-    /// use clawless::prelude::*;
+    /// use clawless_core::cancellation::Cancellation;
     ///
     /// let parent = Cancellation::new();
     /// let child = parent.child();
@@ -101,7 +101,7 @@ impl Cancellation {
     /// # Examples
     ///
     /// ```
-    /// use clawless::prelude::*;
+    /// use clawless_core::cancellation::Cancellation;
     ///
     /// let cancellation = Cancellation::new();
     /// cancellation.cancel();
@@ -124,7 +124,7 @@ impl Cancellation {
     /// # Examples
     ///
     /// ```
-    /// use clawless::prelude::*;
+    /// use clawless_core::cancellation::Cancellation;
     ///
     /// let cancellation = Cancellation::new();
     /// assert!(!cancellation.is_cancelled());
@@ -146,7 +146,7 @@ impl Cancellation {
     /// # Examples
     ///
     /// ```
-    /// use clawless::prelude::*;
+    /// use clawless_core::cancellation::Cancellation;
     ///
     /// # #[tokio::main]
     /// # async fn main() {

--- a/crates/clawless-tui/src/projection/mod.rs
+++ b/crates/clawless-tui/src/projection/mod.rs
@@ -26,11 +26,12 @@
 //!     .expect("should send");
 //! drop(sender);
 //!
-//! // Allow the drain task to process events
-//! tokio::task::yield_now().await;
+//! // Wait for the drain task, which finishes once the dropped sender closes the channel
+//! while !projection.is_complete() {
+//!     tokio::task::yield_now().await;
+//! }
 //!
 //! assert_eq!(projection.entries().len(), 1);
-//! assert!(projection.is_complete());
 //! # }
 //! ```
 //!
@@ -81,7 +82,10 @@ mod state;
 ///     .expect("should send");
 /// drop(sender);
 ///
-/// tokio::task::yield_now().await;
+/// // Wait for the drain task, which finishes once the dropped sender closes the channel
+/// while !projection.is_complete() {
+///     tokio::task::yield_now().await;
+/// }
 ///
 /// let messages = projection.messages();
 /// assert_eq!(messages.len(), 1);

--- a/justfile
+++ b/justfile
@@ -143,6 +143,7 @@ lint-github-actions:
 # `*/*.md` and reaches only the files one directory deep. The `--dot` flag
 # extends the glob into dot-directories such as `.github`, which it skips
 # by default; `.markdownlintignore` excludes the ones we do not lint.
+[doc("Lint Markdown files")]
 lint-markdown:
     markdownlint --dot "**/*.md"
 
@@ -168,5 +169,11 @@ publish:
     cargo publish --all-features --verbose --workspace
 
 # Run the tests
+#
+# nextest does not run doc tests, so a second command covers them. Without it
+# the examples in the documentation never compile, and they drift away from
+# the API they document without anything noticing.
+[doc("Run the tests")]
 test-rust:
     cargo nextest run --all-features --all-targets
+    cargo test --all-features --doc


### PR DESCRIPTION
The test suite runs through nextest, which does not run doc tests, so the examples in the documentation never compiled. They drifted away from the API they document without anything noticing. The `test-rust` recipe now runs `cargo test --doc` as a second command, which extends the coverage to CI as well. A long comment above a recipe also hides its title from `just --list`, because just prints the last comment line, so `test-rust` and `lint-markdown` carry a `doc` attribute that restores it.

The examples for `Cancellation` imported the `clawless` facade, which `clawless-core` cannot depend on without a cycle, so none of the six compiled. They now import the type through its own crate, the way the neighboring examples in `clawless-core` already do.

The two projection examples yielded once to let the drain task process the events they send. That is enough under `#[tokio::test]`, which runs on a current-thread runtime, but the examples run under `#[tokio::main]`, where the drain task lives on a worker thread and the assertion finds an empty projection. Both examples now wait for the projection to report completion, which holds on either runtime.