### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-08-23
+
+### Added
+
+- Add Output, Verbosity, and OutputMode types
+- Add Presenter trait and TerminalPresenter adapter
+- Add clawless-core crate for domain types and ports
+- Create crate for terminal applications
+- Implement Projection type for pull-based event consumption
+- Add `#[application]` macro for TUI applications
+
+### Changed
+
+- Rename output methods and add output macros
+- Rename `clawless-cli` to `cargo-clawless`
+- Extract CLI layer into `clawless-cli` crate
+- Move `Context` to clawless-core
+
 ## [0.5.0] - 2026-02-13
 
 ### Added
@@ -60,6 +78,7 @@ and this project adheres to
 
 - Initial prototype featuring the `clawless!`, `app!`, and `#[command]` macros
 
+[0.6.0]: https://github.com/aonyx-ai/clawless/releases/tag/v0.6.0
 [0.5.0]: https://github.com/aonyx-ai/clawless/releases/tag/v0.5.0
 [0.4.0]: https://github.com/aonyx-ai/clawless/releases/tag/v0.4.0
 [0.3.0]: https://github.com/aonyx-ai/clawless/releases/tag/v0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cancellation"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "clawless",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-clawless"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bon",
@@ -254,7 +254,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clawless"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "clap",
  "clawless-cli",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "clawless-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "clawless-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bon",
  "erased-serde",
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "clawless-derive"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "darling",
  "indoc",
@@ -311,7 +311,7 @@ dependencies = [
 
 [[package]]
 name = "clawless-tui"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -531,7 +531,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello-world"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "clawless",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "output"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "clawless",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["crates/cargo-clawless/tests/commands/new.out"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 
 license = "Apache-2.0 OR MIT"
@@ -22,11 +22,11 @@ assert_cmd = "2.1.1"
 async-trait = "0.1"
 bon = "3"
 clap = { version = "4.3.0", features = ["cargo", "derive"] }
-clawless = { path = "crates/clawless", version = "=0.5.0" }
-clawless-cli = { path = "crates/clawless-cli", version = "=0.5.0" }
-clawless-core = { path = "crates/clawless-core", version = "=0.5.0" }
-clawless-derive = { path = "crates/clawless-derive", version = "=0.5.0" }
-clawless-tui = { path = "crates/clawless-tui", version = "=0.5.0" }
+clawless = { path = "crates/clawless", version = "=0.6.0" }
+clawless-cli = { path = "crates/clawless-cli", version = "=0.6.0" }
+clawless-core = { path = "crates/clawless-core", version = "=0.6.0" }
+clawless-derive = { path = "crates/clawless-derive", version = "=0.6.0" }
+clawless-tui = { path = "crates/clawless-tui", version = "=0.6.0" }
 convert_case = ">=0.1,<1"
 libc = "0.2"
 darling = ">=0.23,<1"


### PR DESCRIPTION
This release refactors the crate layout, moving the user-facing CLI to a Cargo sub-command in `cargo-clawless` and introducing new functionality for building CLIs in `clawless-cli`. And it introduces a fully rewritten output module that supports different verbosities and modes (e.g. `--json`).