### PR TITLE
Specify how Clawless runs external programs

### DIFF
--- a/specs/context.md
+++ b/specs/context.md
@@ -2,8 +2,8 @@
 
 A context is the runtime environment passed to commands and applications. It
 provides access to shared resources: the output channel for emitting events,
-a cancellation token for cooperative shutdown, and the current working
-directory.
+a cancellation token for cooperative shutdown, the current working directory,
+and the interface that runs external programs.
 
 ## Construction
 
@@ -28,6 +28,13 @@ A context MUST provide access to a `Cancellation` token.
 See also [cancel.context.field], [cancel.context.default], and
 [cancel.context.injectable] in the [cancellation spec][cancellation].
 
+## Capabilities
+
+r[context.process]
+A context MUST provide an interface that runs external programs, wired to the
+output and the cancellation token of that context. The [process
+specification][process] defines what such a run does.
+
 ## Thread safety
 
 A context is shared across async tasks. It must be safe to clone and send
@@ -46,3 +53,4 @@ r[context.safety.unpin]
 [cancel.context.field]: cancellation.md#context-integration
 [cancel.context.default]: cancellation.md#context-integration
 [cancel.context.injectable]: cancellation.md#context-integration
+[process]: process.md

--- a/specs/event.md
+++ b/specs/event.md
@@ -7,7 +7,7 @@ displayed.
 
 ## Output
 
-Commands produce three kinds of output, each with different semantics. The
+Commands produce four kinds of output, each with different semantics. The
 presenter uses these semantics to decide what to show based on verbosity and
 output mode.
 
@@ -22,6 +22,10 @@ default verbosity.
 r[event.output.artifact]
 Commands MUST be able to produce structured data as their primary output.
 Artifacts are the main deliverable of a command — the data the user asked for.
+
+r[event.output.process]
+Commands MUST be able to produce the steps of an external program as events. The
+[process specification][process] defines what those steps are.
 
 ## Artifact
 
@@ -87,3 +91,5 @@ Producers MUST be cheaply clonable to share the channel across tasks.
 
 r[event.safety.producer-concurrent]
 Producers MUST be safe for concurrent use from multiple threads.
+
+[process]: process.md

--- a/specs/features/012-run-programs.md
+++ b/specs/features/012-run-programs.md
@@ -1,0 +1,242 @@
+# Run programs
+
+- **Project**: [P004-external-programs][project]
+- **Dependencies**: [F011-output-events][output-events]
+- **Breaking changes**: `Event` and `Entry` gain a variant, so an exhaustive
+  match on either needs a new arm
+
+## Summary
+
+Add [`Process`][process-spec], the interface a command uses to run an external
+program. A run starts the program, sends every line it writes into the [event
+channel][event-channel] as the line arrives, kills the program when the command
+is cancelled, and returns the exit status together with the whole output.
+
+The mechanics of starting a program and reading its streams come from the
+`kawauso-process` crate. This feature is the layer that connects that crate to
+the event system and to the cancellation token of a command.
+
+## Motivation
+
+See the [project motivation][project]. In short, a command that drives another
+program should get live output, no deadlock on a full pipe, cooperative
+shutdown, and an error message that names the command — without writing any of
+it itself.
+
+## Domain concepts
+
+### Invocation and execution
+
+An `Invocation` is the description of a command: a program, its arguments, and
+optionally a working directory. It is a value, so an application can build one,
+write it to a log, and name it in an error without running anything.
+
+An `Execution` is the result of one run: the exit status, what the program
+wrote to each of its streams, and how long the run took. A status that is not a
+success is data, not a failure — the check mode of a formatter exits non-zero
+when it finds a file to format, and that is the answer the caller asked for.
+`Execution::require_success` turns a status the caller cannot accept into an
+error.
+
+Both types come from `kawauso-process` and are re-exported, so an application
+needs Clawless alone.
+
+### Process as the wiring
+
+`Process` holds an `Output` and a `Cancellation`. `Context::process()` builds
+one from the context of a command, which is how a command reaches the
+interface:
+
+```rust
+let execution = context
+    .process()
+    .run(Invocation::new("cargo").arg("build"))
+    .await?
+    .require_success()?;
+```
+
+The handle is separate from the context so that a background task, which has an
+output and a cancellation token but no context, can run a program the same way.
+
+### The events of a run
+
+A run produces one `ProcessEvent::Started`, one `ProcessEvent::Line` per line
+of output, and one `ProcessEvent::Finished`. A consumer therefore knows what is
+running, what it has said so far, and when it stopped.
+
+Every event carries a `RunId`. A command can run two programs at once, and their
+lines then interleave in a single channel; the identity is what separates them
+again. A `RunId` counts runs, which is why it is not the `ProcessId` the
+operating system assigns: that value names a program only while it runs, and the
+operating system reuses it afterwards. `Started` carries both, so that an
+operator can find the program in a process list.
+
+`Started` and `Finished` also carry the `Invocation`, so that a presenter which
+keeps no state can name the program it reports on.
+
+`Finished` carries an `Outcome`, which says which of the three ends it was: the
+program exited with a status, cancellation stopped it, or the run produced no
+result. Modelling the end as an outcome rather than a status is what makes the
+guarantee "every run that reports its start also reports its end" possible, and
+that guarantee is what lets a TUI remove a running program from its view.
+
+### Cancellation ends the program
+
+Both the read of the output and the wait for the end race the cancellation
+token. A program that writes without end stops when the user asks for it, and
+so does a program that closed its streams and kept running.
+
+A cancelled program is asked to end and killed only if it does not answer within
+the grace period, so a build tool gets the moment it needs to remove its lock
+file. The grace period bounds the whole ending, so a program that ignores the
+request costs that period and a program that answers costs what it takes to
+answer.
+
+This holds on both paths. Waiting for the end of a program leaves the handle
+where it is, so a program that closed both of its streams and kept running is
+asked to end like any other.
+
+The cancellation branch is biased first, which means a token that is already
+cancelled ends the run instead of reporting one more line.
+
+### Rendering
+
+The output of a program is supplementary: the presenter shows it at verbose
+verbosity, in the same way it shows a detail. A command that wants a program to
+be visible at the default verbosity says so itself with a message.
+
+In text mode the presenter keeps the two streams apart, writing what the
+program wrote to its standard error to the standard error of the application.
+Redirecting one of the two streams therefore gives the same split as running
+the program by hand. In JSON mode everything goes to standard error, because
+standard output carries artifacts alone.
+
+## Functional requirements
+
+1. `Process::run` starts a program, streams its output as events, and returns
+   an `Execution`.
+2. The `Execution` carries the whole output of the program, whether or not a
+   consumer read the events.
+3. Cancellation ends the program and returns an error that names the command,
+   while the program writes and after it stops writing. The program is asked to
+   end before it is killed, and the grace period bounds the whole ending.
+4. A run that reports its start also reports its end, on every path that can
+   still reach the consumer and that the caller did not abandon.
+5. `Context::process()` returns a `Process` wired to the output and the
+   cancellation token of the context.
+6. `TerminalPresenter` renders process events at verbose verbosity only, and
+   keeps the two streams of the program apart in text mode.
+7. `Projection` stores process events as entries and offers a filtered query
+   for them.
+8. `just pre-commit` passes.
+
+## Non-functional requirements
+
+1. **No deadlock on a full pipe**: both streams are read while the run waits.
+2. **Cheap projection queries**: a process entry is behind an `Arc`, because a
+   run produces one entry per line and a render frame clones what it reads.
+3. **No shell**: nothing splits an argument at a space or expands a `*`, so an
+   argument that holds a space stays one argument.
+4. **Null standard input**: a program that asks for a password ends instead of
+   waiting for an answer that no one will type.
+
+## API surface
+
+```rust
+// clawless_core::process
+pub struct Process { /* output, cancellation, grace_period */ }
+
+impl Process {
+    pub fn builder() -> ProcessBuilder;
+    pub async fn run(&self, invocation: Invocation) -> Result<Execution, RunProcessError>;
+}
+
+pub enum RunProcessError {
+    CancelledRun { invocation: Invocation },
+    UnrunnableCommand { source: RunCommandError },
+    UnreportableOutput { invocation: Invocation, source: SendError },
+}
+
+// clawless_core::event::process
+pub enum ProcessEvent {
+    Started { id: RunId, invocation: Invocation, process_id: Option<ProcessId> },
+    Line { id: RunId, line: Line },
+    Finished { id: RunId, invocation: Invocation, outcome: Outcome, duration: Duration },
+}
+
+pub enum Outcome {
+    Cancelled,
+    Exited(ExitStatus),
+    Incomplete,
+}
+
+pub struct RunId(/* u64 */);
+
+// clawless_core::context
+impl Context {
+    pub fn process(&self) -> Process;
+}
+
+// clawless_core::output
+impl Output {
+    pub async fn process_event(&self, event: ProcessEvent) -> Result<(), SendError>;
+}
+
+// clawless_tui::projection
+impl Projection {
+    pub fn processes(&self) -> Vec<Entry>;
+}
+```
+
+## File changes
+
+### New files
+
+| File                                                | Purpose                    |
+| --------------------------------------------------- | -------------------------- |
+| `crates/clawless-core/src/process/mod.rs`           | `Process` and its run loop |
+| `crates/clawless-core/src/process/error.rs`         | `RunProcessError`          |
+| `crates/clawless-core/src/event/process/mod.rs`     | `ProcessEvent`             |
+| `crates/clawless-core/src/event/process/run_id.rs`  | `RunId`                    |
+| `crates/clawless-core/src/event/process/outcome.rs` | `Outcome`                  |
+| `examples/process/`                                 | Example and its tests      |
+
+### Modified files
+
+| File                                            | Change                         |
+| ----------------------------------------------- | ------------------------------ |
+| `crates/clawless-core/src/event/mod.rs`         | `Event::Process` variant       |
+| `crates/clawless-core/src/output.rs`            | `Output::process_event`        |
+| `crates/clawless-core/src/context/mod.rs`       | `Context::process`             |
+| `crates/clawless-cli/src/presenter/terminal.rs` | Render process events          |
+| `crates/clawless-tui/src/projection/entry.rs`   | `Entry::Process` variant       |
+| `crates/clawless-tui/src/projection/mod.rs`     | `Projection::processes`        |
+| `crates/clawless/src/lib.rs`                    | Re-export the `process` module |
+
+## Edge cases
+
+| Case                                          | Expected behavior                                         |
+| --------------------------------------------- | --------------------------------------------------------- |
+| Program does not exist                        | `UnrunnableCommand`, no start event, no run               |
+| Program exits non-zero                        | `Ok(Execution)`; `require_success` turns it into an error |
+| Program writes more than a pipe holds         | Both streams are read while waiting, so the run finishes  |
+| Program closes its streams and keeps running  | The wait races cancellation, so Ctrl+C still ends the run |
+| Program writes a last line without a newline  | That line is reported                                     |
+| Program writes bytes that are not valid UTF-8 | The line shows `U+FFFD`; the capture keeps the bytes      |
+| Token already cancelled before the run        | Started, then Finished with `Cancelled`, then an error    |
+| Consumer of the events is gone                | `UnreportableOutput`; the program is killed with the run  |
+| Two programs run at once                      | Their lines interleave and the `ProcessId` separates them |
+
+## Out of scope
+
+See the [project][project]. Environment control, standard input, pipelines, and
+default-verbosity rendering are all left for later.
+
+## Open questions
+
+None. All design decisions for this feature have been resolved.
+
+[event-channel]: 007-event-channel.md
+[output-events]: 011-output-events.md
+[process-spec]: ../process.md
+[project]: ../projects/004-external-programs.md

--- a/specs/output.md
+++ b/specs/output.md
@@ -6,7 +6,7 @@ from the rendering strategy.
 
 ## Sending events
 
-Commands produce three kinds of output through Output. Each method sends an
+Commands produce four kinds of output through Output. Each method sends an
 event into the channel for the presenter to consume.
 
 r[output.send.message]
@@ -17,6 +17,10 @@ Output MUST be able to send supplementary text as an event.
 
 r[output.send.artifact]
 Output MUST be able to send structured data as an event.
+
+r[output.send.process]
+Output MUST be able to send one step in the run of an external program as an
+event.
 
 r[output.send.async]
 Sending output MUST be an asynchronous operation.

--- a/specs/process.md
+++ b/specs/process.md
@@ -1,0 +1,150 @@
+# Process
+
+Process is the interface that runs an external program from a command. Most
+command-line applications drive other programs, and a run reports what the
+program does through the event system while it happens, so that a presenter can
+show progress instead of waiting for the program to end.
+
+## Running a program
+
+A run takes the description of a command, starts the program, and reports what
+the program produced.
+
+r[process.new]
+Process MUST be constructible from an output and a cancellation token.
+
+r[process.new.grace]
+The time a program gets to end itself before Clawless kills it MUST be
+configurable, and it MUST have a default.
+
+r[process.run]
+Process MUST be able to run an external program and return its result. The
+result carries the exit status, the output of both streams, and the time that
+the run took.
+
+r[process.run.capture]
+A run MUST report the whole output of the program in its result, whether or not
+a consumer read the output while the program ran.
+
+r[process.run.stream]
+A run MUST report each line of output as an event before the program ends.
+
+r[process.run.lifecycle]
+A run that reports its start MUST also report its end, whatever ends it. A run
+whose consumer stopped listening, and a run that the caller dropped instead of
+cancelling, are the two exceptions, because neither leaves anyone to send the
+event.
+
+r[process.run.error]
+A program that does not start, and a run that produces no result, MUST return an
+error.
+
+r[process.run.report.error]
+A run whose events can no longer be delivered MUST return an error.
+
+## Cancellation
+
+A program that a command started outlives the command unless the command stops
+it. A run therefore observes the cancellation token of its command.
+
+r[process.run.cancel]
+Cancellation MUST stop a run and end the program, whether the program is writing
+output or has stopped writing.
+
+r[process.run.cancel.grace]
+Cancellation MUST ask the program to end before it kills it, and give it the
+grace period to answer. A build tool that holds a lock file can then remove it,
+which a kill gives it no time to do.
+
+r[process.run.cancel.bound]
+A cancelled run MUST end within the grace period, whatever the program does with
+the request.
+
+r[process.run.cancel.error]
+A run that cancellation stopped MUST return an error that names the command.
+
+## Errors
+
+r[process.error]
+Each way in which a run can fail MUST be a variant of its own, so that a command
+can treat cancellation differently from a program that never ran.
+
+## Events
+
+A run reports itself as events, which is what lets a presenter render a program
+while it runs.
+
+r[process.event.lifecycle]
+The events of a run MUST describe its start, each line of its output, and its
+end.
+
+r[process.event.started]
+The start of a run MUST name the command.
+
+r[process.event.started.identifier]
+The start of a run MUST carry the identifier that the operating system gave the
+program, when the operating system reports one. An operator who looks for the
+program in a process list needs that value, and no other event carries it.
+
+r[process.event.line]
+A line of output MUST carry the stream that produced it and the text of the
+line, without the characters that ended it.
+
+r[process.event.finished]
+The end of a run MUST name the command, say how the run ended, and report the
+time that the run took.
+
+r[process.event.display]
+An event of a run MUST be renderable as one line of a transcript.
+
+r[process.event.correlation]
+Every event of a run MUST carry the identity of that run, so that a consumer can
+separate two programs that run at the same time. That identity counts runs and
+is not the identifier that the operating system gives a program, which names a
+program only while it runs and which the operating system reuses afterwards.
+
+r[process.event.correlation.unique]
+No two runs of one application MUST share an identity.
+
+r[process.event.correlation.accessor]
+A consumer MUST be able to read the identity of an event without matching on the
+kind of the event.
+
+## Outcome
+
+r[process.event.outcome]
+The end of a run MUST say which of the ends it was.
+
+r[process.event.outcome.exited]
+A program that ran to its end MUST report its exit status. A status that is not
+a success is a result and not a failure.
+
+r[process.event.outcome.cancelled]
+A program that cancellation stopped MUST report that it was cancelled.
+
+r[process.event.outcome.incomplete]
+A run that produced no result MUST report that it produced none.
+
+## Rendering
+
+r[process.render.verbosity]
+A presenter MUST treat the output of an external program as supplementary, and
+show it only at verbose verbosity.
+
+r[process.render.streams]
+A presenter that writes to a terminal MUST keep the two streams of the program
+apart, so that what the program wrote to its standard error reaches the standard
+error of the application.
+
+## Thread safety
+
+Runs happen in async tasks, and a command can start several of them at once.
+
+r[process.safety.clone]
+Process MUST be cheaply clonable to share across tasks.
+
+r[process.safety.send]
+Process MUST be sendable across thread boundaries.
+
+r[process.safety.sync]
+Process MUST be safe for concurrent use from multiple threads.

--- a/specs/projection.md
+++ b/specs/projection.md
@@ -31,6 +31,11 @@ A projection MUST store detail events as entries carrying the detail text.
 r[projection.entry.artifact]
 A projection MUST store artifact events as entries carrying the artifact value.
 
+r[projection.entry.process]
+A projection MUST store the events of an external program as entries carrying
+those events. An entry MUST be cheap to clone, because a run produces one entry
+per line of output and a render frame clones the entries it reads.
+
 r[projection.entry.order]
 Entries MUST be stored in the order they were received from the event channel.
 
@@ -50,6 +55,10 @@ A projection MUST provide filtered access to detail entries only.
 
 r[projection.query.artifacts]
 A projection MUST provide filtered access to artifact entries only.
+
+r[projection.query.processes]
+A projection MUST provide filtered access to the entries of external programs
+only, so that a view can show the last lines that a program wrote.
 
 ## Lifecycle
 

--- a/specs/projects/004-external-programs.md
+++ b/specs/projects/004-external-programs.md
@@ -1,0 +1,56 @@
+# External programs
+
+## Summary
+
+A first-class interface for running external programs from a Clawless command.
+The interface streams the output of a program through the [event system][event]
+as the program writes it, so that a [presenter][presenter-rendering] can show a
+long-running tool while it runs, and a [projection][projection] can keep the
+last few lines of it on screen.
+
+## Motivation
+
+Most command-line applications drive other programs. A release tool calls
+`git`, a scaffolding tool calls `cargo`, and a deployment tool calls the client
+of its provider. Today a Clawless command reaches for `std::process::Command`
+or `tokio::process::Command` and then has to solve the same four problems every
+time:
+
+- **Pipes that fill.** A program that writes more than a pipe holds stops until
+  a reader empties it. A command that waits for the end before it reads
+  deadlocks on a talkative program.
+- **Output that arrives too late.** A command that collects the output and
+  prints it afterwards shows nothing for two minutes and then everything at
+  once.
+- **Programs that outlive the command.** A command that is cancelled leaves its
+  program running unless it kills the program itself.
+- **Errors that say nothing.** "exit status 1" does not tell a user which
+  command failed or what it said.
+
+The event system solves the second problem for a command's own output already.
+This project connects a running program to it: the lines of the program become
+events, and the presenter decides what to do with them. The command's code is
+the same whether it runs under a stateless CLI or a full-screen TUI.
+
+## Feature specs
+
+Each feature spec maps to one PR.
+
+| #    | Spec                              | Depends on | Summary                                   |
+| ---- | --------------------------------- | ---------- | ----------------------------------------- |
+| F012 | [F012-run-programs][run-programs] |            | `Process`, process events, live streaming |
+
+## Out of scope
+
+The first feature runs a program and reports it. These extensions are
+deliberately left for later, when a real application asks for them:
+
+- Setting or clearing environment variables for a program.
+- Writing to the standard input of a program.
+- Running a pipeline of programs.
+- A presenter that shows the output of a program at default verbosity.
+
+[event]: ../event.md
+[presenter-rendering]: ../features/009-presenter-rendering.md
+[projection]: ../projection.md
+[run-programs]: ../features/012-run-programs.md


### PR DESCRIPTION
Most command-line applications drive other programs, and a Clawless command that does so today reaches for `tokio::process::Command` and solves the same problems every time: a pipe that fills and stops the program, output that only appears once the program ended, a program that keeps running after the user pressed Ctrl+C, and an error that says no more than "exit status 1".

This specification defines the interface that answers those, ahead of the implementation. A run reports itself through the event system as it happens, so a presenter can show a long build while it runs and a projection can keep the last few lines of it. Cancellation ends the program, asking before it kills. The result carries the exit status and the whole output, and a status that is not a success is data rather than a failure.

The rules that other components gain are the seams this needs: an event kind for the steps of a run, a way for output to send one, a context that hands a command the interface, and a projection that stores and answers for them.
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
