### PR TITLE
Run external programs from a command

### DIFF
--- a/crates/clawless-core/src/context/mod.rs
+++ b/crates/clawless-core/src/context/mod.rs
@@ -14,6 +14,7 @@ pub use self::current_working_directory::CurrentWorkingDirectory;
 pub use self::error::ContextError;
 use crate::cancellation::Cancellation;
 use crate::output::Output;
+use crate::process::Process;
 
 /// Newtype for the directory that a command runs in
 mod current_working_directory;
@@ -111,6 +112,43 @@ impl Context {
     }
 }
 
+impl Context {
+    /// Returns the interface that runs external programs
+    ///
+    /// The returned [`Process`] reports every run through the output of this context and stops a
+    /// run when the cancellation token of this context is cancelled. A command therefore gets live
+    /// output and cooperative shutdown without wiring either of them itself.
+    ///
+    /// Each call builds a handle over the same channel and the same token, so a command can call
+    /// this method wherever it runs a program instead of holding the handle.
+    ///
+    /// The handle takes the default grace period, which is the time a program gets to end itself
+    /// before Clawless kills it. A command that drives a program needing longer builds its own
+    /// handle with [`Process::builder`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// #[command]
+    /// pub async fn build(args: BuildArgs, context: Context) -> CommandResult {
+    ///     context
+    ///         .process()
+    ///         .run(Invocation::new("cargo").arg("build"))
+    ///         .await?
+    ///         .require_success()?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    // r[impl context.process]
+    pub fn process(&self) -> Process {
+        Process::builder()
+            .output(self.output.clone())
+            .cancellation(self.cancellation.clone())
+            .build()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     // An assertion in a test panics by design. A `# Panics` section on every test
@@ -120,7 +158,9 @@ mod tests {
     use std::path::Path;
 
     use super::*;
+    use crate::event::Event;
     use crate::event::event_channel;
+    use crate::process::Invocation;
 
     fn test_output() -> Output {
         let (sender, _receiver) = event_channel();
@@ -181,6 +221,34 @@ mod tests {
             .expect("should create context");
 
         assert!(!context.cancellation().is_cancelled());
+    }
+
+    // r[verify context.process]
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn process_reports_through_the_output_of_the_context() {
+        let (sender, mut receiver) = event_channel();
+        let context = Context::builder()
+            .output(Output::new(sender))
+            .build()
+            .expect("should build");
+        let invocation = Invocation::new("sh").arg("-c").arg("exit 0");
+
+        context
+            .process()
+            .run(invocation.clone())
+            .await
+            .expect("should run");
+
+        assert_eq!(
+            receiver.recv().await.map(|event| match event {
+                Event::Process(event) => event.to_string(),
+                Event::Message(text) => text,
+                Event::Detail(text) => text,
+                Event::Artifact(artifact) => artifact.to_string(),
+            }),
+            Some(format!("$ {invocation}"))
+        );
     }
 
     // r[verify context.safety.send]

--- a/crates/clawless-core/src/event/process/run_id.rs
+++ b/crates/clawless-core/src/event/process/run_id.rs
@@ -6,8 +6,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// The source of the identities that [`RunId::next`] hands out
 ///
 /// The counter is a single static, so every identity is unique within the
-/// process regardless of which handle hands it out. A counter per handle would
-/// repeat itself as soon as a command cloned its context.
+/// process regardless of which [`Process`] handed it out. A counter per handle
+/// would repeat itself as soon as a command cloned its context.
+///
+/// [`Process`]: crate::process::Process
 static NEXT_RUN_ID: AtomicU64 = AtomicU64::new(0);
 
 /// The identity of one run of an external program
@@ -45,9 +47,9 @@ pub struct RunId(u64);
 impl RunId {
     /// Returns an identity that no earlier call returned
     ///
-    /// A run calls this once, so a command that runs a program does not need
-    /// it. A test that stands in for a run builds its events with identities
-    /// from here.
+    /// [`Process::run`] calls this once per run, so a command that runs a
+    /// program does not need it. A test that stands in for a run builds its
+    /// events with identities from here.
     ///
     /// The counter wraps after `2^64` runs. An application that started a
     /// program every nanosecond would reach that point after more than five
@@ -62,6 +64,8 @@ impl RunId {
     ///
     /// assert_eq!(id, id);
     /// ```
+    ///
+    /// [`Process::run`]: crate::process::Process::run
     // r[impl process.event.correlation.unique]
     pub fn next() -> Self {
         Self(NEXT_RUN_ID.fetch_add(1, Ordering::Relaxed))

--- a/crates/clawless-core/src/lib.rs
+++ b/crates/clawless-core/src/lib.rs
@@ -18,5 +18,5 @@ pub mod signal;
 pub mod prelude {
     pub use super::cancellation::Cancellation;
     pub use super::context::{Context, ContextError, CurrentWorkingDirectory};
-    pub use super::process::{Execution, Invocation};
+    pub use super::process::{Execution, Invocation, Process};
 }

--- a/crates/clawless-core/src/output.rs
+++ b/crates/clawless-core/src/output.rs
@@ -5,8 +5,10 @@
 //! rendering strategy. Commands call [`message`], [`detail`], or [`artifact`] to emit events into
 //! the channel; the Presenter consumes them and decides how to render.
 //!
-//! [`process_event`] carries the steps of an external program that a command runs.
+//! [`process_event`] carries the steps of an external program that a command runs. Commands do not
+//! usually call it, because [`Process`] reports a run through it.
 //!
+//! [`Process`]: crate::process::Process
 //! [`artifact`]: Output::artifact
 //! [`detail`]: Output::detail
 //! [`message`]: Output::message
@@ -184,8 +186,9 @@ impl Output {
 
     /// Sends one step in the run of an external program
     ///
-    /// An application that drives an external program, and wants its output to reach the presenter
-    /// as the program writes it, reports each step of the run through this method.
+    /// [`Process`] calls this for every step of a run, so a command that runs a program through
+    /// Clawless does not call it. An application that drives a program itself, and wants its
+    /// output to reach the presenter in the same shape, reports the run through this method.
     ///
     /// # Errors
     ///
@@ -216,6 +219,7 @@ impl Output {
     /// ```
     ///
     /// [`EventReceiver`]: crate::event::EventReceiver
+    /// [`Process`]: crate::process::Process
     // r[impl output.send.process]
     pub async fn process_event(&self, event: ProcessEvent) -> Result<(), SendError> {
         self.sender.send(Event::Process(Box::new(event))).await

--- a/crates/clawless-core/src/process/error.rs
+++ b/crates/clawless-core/src/process/error.rs
@@ -1,0 +1,128 @@
+//! The error of running an external program from a command
+
+use kawauso_process::Invocation;
+use kawauso_process::error::RunCommandError;
+use thiserror::Error;
+
+use crate::event::SendError;
+
+/// The error returned when a command cannot run an external program
+///
+/// The variants separate what a caller does about the failure. A command that
+/// was cancelled stops, a command whose program never ran reports the program,
+/// and a command whose output can no longer be reported has lost its presenter
+/// and ends.
+///
+/// A program that ran and ended without success is no failure of the run. The
+/// [`Execution`] then carries the status, and [`require_success`][success] turns
+/// a status that the caller cannot accept into an error of its own.
+///
+/// A later release can add variants, and it can add fields to a variant. Match
+/// with a wildcard arm, and bind the fields of a variant with `..`.
+///
+/// [`Execution`]: kawauso_process::Execution
+/// [success]: kawauso_process::Execution::require_success
+// r[impl process.error]
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum RunProcessError {
+    /// Cancellation stopped the program before it ended
+    ///
+    /// Clawless killed the program, so the run has no exit status and no
+    /// complete output. A command that treats cancellation as an orderly end
+    /// matches this variant and returns without an error.
+    // r[impl process.run.cancel.error]
+    #[error("the command `{invocation}` was cancelled before it ended")]
+    #[non_exhaustive]
+    CancelledRun {
+        /// The command that was cancelled
+        invocation: Invocation,
+    },
+
+    /// The program could not be run
+    ///
+    /// No program answers to the name, the working directory does not exist,
+    /// the operating system refused to start the program, or the run started
+    /// and its result could not be collected. The message is the one of the
+    /// underlying failure, because this layer knows nothing that the run does
+    /// not already state.
+    // r[impl process.run.error]
+    #[error(transparent)]
+    #[non_exhaustive]
+    UnrunnableCommand {
+        /// The cause of the failure
+        source: RunCommandError,
+    },
+
+    /// The output of the program could not be reported
+    ///
+    /// The presenter stopped listening while the program ran, so the run has no
+    /// consumer left. The program itself was killed with the run.
+    // r[impl process.run.report.error]
+    #[error("failed to report the output of the command `{invocation}`")]
+    #[non_exhaustive]
+    UnreportableOutput {
+        /// The command whose output could not be reported
+        invocation: Invocation,
+
+        /// The cause of the failure
+        source: SendError,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    // An assertion in a test panics by design. A `# Panics` section on every test
+    // would repeat that and give the reader no information.
+    #![allow(clippy::missing_panics_doc)]
+
+    use super::*;
+
+    // r[verify process.error]
+    #[test]
+    fn display_with_a_cancelled_run_names_the_command() {
+        let error = RunProcessError::CancelledRun {
+            invocation: Invocation::new("git").arg("status"),
+        };
+
+        let message = error.to_string();
+
+        assert_eq!(
+            message,
+            "the command `git status` was cancelled before it ended"
+        );
+    }
+
+    #[test]
+    fn display_with_unreportable_output_names_the_command() {
+        let error = RunProcessError::UnreportableOutput {
+            invocation: Invocation::new("git").arg("status"),
+            source: SendError(crate::event::Event::Message("lost".to_owned())),
+        };
+
+        let message = error.to_string();
+
+        assert_eq!(
+            message,
+            "failed to report the output of the command `git status`"
+        );
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<RunProcessError>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<RunProcessError>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<RunProcessError>();
+    }
+}

--- a/crates/clawless-core/src/process/mod.rs
+++ b/crates/clawless-core/src/process/mod.rs
@@ -1,36 +1,1000 @@
-//! The vocabulary of external programs
+//! Running external programs from a command
 //!
-//! Most command-line applications drive other programs. This module names what
-//! such a program is described by and what it produces, so that a command, a
-//! presenter, and a projection all speak of a run in the same terms.
+//! Most command-line applications drive other programs. A release tool calls
+//! `git`, a build tool calls `cargo`, and a deployment tool calls a provider's
+//! own client. This module defines [`Process`], the interface that runs such a
+//! program and reports it through the event system while it runs.
 //!
-//! The description of a command is an [`Invocation`]: a program, its arguments,
-//! and optionally the directory it runs in. It is a value, so an application
-//! can build one, write it to a log, and name it in an error without running
-//! anything.
+//! A run reports itself as [`ProcessEvent`]s: one for the start, one for every
+//! line that the program writes, and one for the end. A presenter therefore
+//! shows a long build as it happens, and a TUI can keep the last few lines of
+//! the program in a corner of the screen. The command's own code is the same in
+//! both cases.
 //!
-//! The result of a run is an [`Execution`]: the exit status, what the program
-//! wrote to each of its streams, and the time the run took. A status that is
-//! not a success is data rather than a failure — the check mode of a formatter
-//! ends without success when it finds a file to format, and that is the answer
-//! the caller asked for.
-//!
-//! These types come from the `kawauso-process` crate, which owns the mechanics
-//! of starting a program and reading its streams. This module re-exports what
-//! an application names, so that it needs Clawless alone.
+//! The description of a command is an [`Invocation`], and the result of a run
+//! is an [`Execution`]. Both come from the `kawauso-process` crate, which owns
+//! the mechanics of starting a program and reading its streams. This module
+//! re-exports what a command names, so that an application needs Clawless
+//! alone.
 //!
 //! # Examples
 //!
-//! ```
-//! use clawless_core::process::Invocation;
+//! ```no_run
+//! use clawless_core::process::{Invocation, Process};
 //!
-//! let invocation = Invocation::new("git").arg("status").arg("--short");
+//! # async fn example(process: Process) -> Result<(), Box<dyn std::error::Error>> {
+//! let execution = process
+//!     .run(Invocation::new("git").arg("status").arg("--short"))
+//!     .await?
+//!     .require_success()?;
 //!
-//! assert_eq!(invocation.to_string(), "git status --short");
+//! let status = execution.stdout().to_string_lossy();
+//! # Ok(())
+//! # }
 //! ```
+//!
+//! [`ProcessEvent`]: crate::event::process::ProcessEvent
 
+use std::time::{Duration, Instant};
+
+use bon::Builder;
 pub use kawauso_process::error::{RequireSuccessError, RunCommandError};
 pub use kawauso_process::execution::Capture;
 pub use kawauso_process::invocation::{Argument, Program, WorkingDirectory};
 pub use kawauso_process::run::{Line, Stream, Text};
 pub use kawauso_process::{Execution, Invocation, ProcessId, Run};
+
+pub use self::error::RunProcessError;
+use crate::cancellation::Cancellation;
+use crate::event::SendError;
+use crate::event::process::{Outcome, ProcessEvent, RunId};
+use crate::output::Output;
+
+/// The time a program gets to end itself before Clawless kills it
+///
+/// A program that answers the request costs what it takes to answer, so this
+/// period is only ever paid in full by a program that ignores it. Five seconds
+/// is therefore generous where it costs nothing and still short enough that a
+/// user who pressed Ctrl+C on such a program does not think the application
+/// ignored them. A program that cleans up for longer says so through the
+/// builder.
+const DEFAULT_GRACE_PERIOD: Duration = Duration::from_secs(5);
+
+/// The error of running an external program from a command
+mod error;
+
+/// The way in which the reading of the output of a program ended
+///
+/// A read that ends because the program closed its streams still owes the
+/// caller the exit status, and a read that ends because cancellation stopped
+/// the run owes nothing. The two ends therefore travel apart.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum Streamed {
+    /// Cancellation stopped the run
+    Cancelled,
+
+    /// Both output streams of the program reached their end
+    Closed,
+}
+
+/// Runs external programs and reports them through the event system
+///
+/// `Process` holds the two things that a run needs: the [`Output`] that carries
+/// its events, and the [`Cancellation`] that stops it. [`Context::process`]
+/// builds one from the context of a command, which is how a command reaches
+/// this interface.
+///
+/// A run reports every line that the program writes as it arrives, so a
+/// presenter can render the progress of a program that takes minutes. The same
+/// lines also reach the caller in the [`Execution`], which means that a command
+/// can show the output and read it afterwards without running the program
+/// twice.
+///
+/// Cancellation ends the program. A command that observes its cancellation token
+/// therefore does not leave a build running after the user pressed Ctrl+C, and
+/// it needs no code of its own to achieve that. The program is asked to end
+/// first and killed only if it does not, so a build tool gets the moment it
+/// needs to remove its lock file. The [builder] names how long that moment is.
+///
+/// [builder]: Process::builder
+///
+/// `Process` is cheaply clonable. Cloning produces another handle to the same
+/// event channel and the same cancellation token.
+///
+/// # Examples
+///
+/// ```no_run
+/// use clawless_core::process::{Invocation, Process};
+///
+/// # async fn example(process: Process) -> Result<(), Box<dyn std::error::Error>> {
+/// let execution = process.run(Invocation::new("cargo").arg("build")).await?;
+///
+/// let succeeded = execution.status().success();
+/// # Ok(())
+/// # }
+/// ```
+///
+/// [`Context::process`]: crate::context::Context::process
+// r[impl process.new]
+// r[impl process.new.grace]
+// r[impl process.safety.clone]
+// r[impl process.safety.send]
+// r[impl process.safety.sync]
+#[derive(Clone, Debug, Builder)]
+pub struct Process {
+    /// The channel that carries the events of a run
+    output: Output,
+
+    /// The token that stops a run
+    #[builder(default)]
+    cancellation: Cancellation,
+
+    /// The time a program gets to end itself before Clawless kills it
+    #[builder(default = DEFAULT_GRACE_PERIOD)]
+    grace_period: Duration,
+}
+
+impl Process {
+    /// Runs a program and reports its output while it runs
+    ///
+    /// The method starts the program, sends every line that it writes into the
+    /// event channel as the line arrives, waits for the program to end, and
+    /// returns what the program produced. The [`Execution`] holds the exit
+    /// status, both output streams as the program wrote them, and the time that
+    /// the run took.
+    ///
+    /// A program that ends without success is not a failure of this method. The
+    /// status travels in the [`Execution`], and
+    /// [`require_success`][success] turns a status that the caller cannot
+    /// accept into an error.
+    ///
+    /// Cancellation ends the program: it is asked to end, and killed only if it
+    /// does not answer within the grace period. The run then returns
+    /// [`CancelledRun`][cancelled], and the events of the run end with an
+    /// [`Outcome::Cancelled`].
+    ///
+    /// The program starts with a standard input that is null, so a program that
+    /// asks for a password ends instead of waiting for an answer. It inherits
+    /// the environment of the application, and the operating system resolves
+    /// its name.
+    ///
+    /// The future of this method owns the program. A caller that drops it, in a
+    /// timeout of its own for example, kills the program with it and no event
+    /// reports the end of the run. Stop a run through the cancellation token
+    /// instead, which asks the program to end and closes its events.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UnrunnableCommand`][unrunnable] when the program does not
+    /// start or the run produces no result, [`CancelledRun`][cancelled] when
+    /// cancellation stopped the program, and
+    /// [`UnreportableOutput`][unreportable] when the presenter stopped
+    /// listening while the program ran.
+    ///
+    /// # Panics
+    ///
+    /// Panics when no Tokio runtime drives the future. Commands always run
+    /// under one.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use clawless_core::process::{Invocation, Process};
+    ///
+    /// # async fn example(process: Process) -> Result<(), Box<dyn std::error::Error>> {
+    /// let execution = process
+    ///     .run(Invocation::new("git").arg("rev-parse").arg("HEAD"))
+    ///     .await?
+    ///     .require_success()?;
+    ///
+    /// let commit = execution.stdout().to_string_lossy().trim().to_owned();
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`Outcome::Cancelled`]: crate::event::process::Outcome::Cancelled
+    /// [cancelled]: RunProcessError::CancelledRun
+    /// [success]: Execution::require_success
+    /// [unreportable]: RunProcessError::UnreportableOutput
+    /// [unrunnable]: RunProcessError::UnrunnableCommand
+    // r[impl process.run]
+    // r[impl process.run.capture]
+    // r[impl process.run.stream]
+    pub async fn run(&self, invocation: Invocation) -> Result<Execution, RunProcessError> {
+        let started = Instant::now();
+        let id = RunId::next();
+
+        let mut run = invocation
+            .start()
+            .map_err(|source| RunProcessError::UnrunnableCommand { source })?;
+
+        let event = ProcessEvent::Started {
+            id,
+            invocation: invocation.clone(),
+            process_id: run.id(),
+        };
+        self.report(&invocation, event).await?;
+
+        let streamed = self.stream(id, &invocation, &mut run).await;
+
+        match streamed {
+            Ok(Streamed::Closed) => self.complete(id, invocation, run, started).await,
+            Ok(Streamed::Cancelled) => Err(self.cancel(id, invocation, run, started).await),
+            Err(error) => {
+                drop(run.stop(self.grace_period).await);
+                drop(
+                    self.end(id, &invocation, Outcome::Incomplete, started)
+                        .await,
+                );
+
+                Err(error)
+            }
+        }
+    }
+
+    /// Ends a run that cancellation stopped and reports it
+    ///
+    /// The program is asked to end and killed only if it does not answer within
+    /// the grace period, so a build tool that holds a lock file gets the moment
+    /// it needs to remove it.
+    ///
+    /// What the program writes while it ends reaches the capture of the run and
+    /// not the event channel, because the ending owns the streams. A consumer
+    /// therefore sees the lines up to the cancellation and then the end of the
+    /// run.
+    ///
+    /// The grace period bounds the whole ending, so a program that ignores the
+    /// request costs that period and a program that answers costs what it takes
+    /// to answer.
+    ///
+    /// The result of the ending is dropped. The caller is cancelling, so it
+    /// discards the output of the run either way, and a program that could not
+    /// be waited for is no longer this application's concern.
+    // r[impl process.run.cancel.grace]
+    // r[impl process.run.cancel.bound]
+    async fn cancel(
+        &self,
+        id: RunId,
+        invocation: Invocation,
+        run: Run,
+        started: Instant,
+    ) -> RunProcessError {
+        drop(run.stop(self.grace_period).await);
+        drop(self.end(id, &invocation, Outcome::Cancelled, started).await);
+
+        RunProcessError::CancelledRun { invocation }
+    }
+
+    /// Reports every line of the program until it stops writing
+    ///
+    /// The read and the cancellation token race on every line, so a program
+    /// that writes without end still stops when the user asks for it. The
+    /// cancellation branch comes first, which means that a token that is
+    /// already cancelled ends the run instead of reporting one more line.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UnrunnableCommand`][unrunnable] when a stream of the program
+    /// cannot be read, and [`UnreportableOutput`][unreportable] when a line
+    /// cannot be reported.
+    ///
+    /// [unreportable]: RunProcessError::UnreportableOutput
+    /// [unrunnable]: RunProcessError::UnrunnableCommand
+    // r[impl process.run.cancel]
+    async fn stream(
+        &self,
+        id: RunId,
+        invocation: &Invocation,
+        run: &mut Run,
+    ) -> Result<Streamed, RunProcessError> {
+        loop {
+            let line = tokio::select! {
+                biased;
+
+                () = self.cancellation.cancelled() => return Ok(Streamed::Cancelled),
+                line = run.next_line() => line,
+            };
+
+            let line = line.map_err(|source| RunProcessError::UnrunnableCommand { source })?;
+
+            let Some(line) = line else {
+                return Ok(Streamed::Closed);
+            };
+
+            self.report(invocation, ProcessEvent::Line { id, line })
+                .await?;
+        }
+    }
+
+    /// Waits for a program that stopped writing and reports how it ended
+    ///
+    /// A program can close both of its output streams and keep running, so the
+    /// wait races the cancellation token as the read does.
+    ///
+    /// The wait leaves the handle where it is, so cancellation here ends the
+    /// program the same way it does while the program is writing: a request,
+    /// the grace period, and a kill only if the program does not answer.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CancelledRun`][cancelled] when cancellation stopped the
+    /// program, [`UnrunnableCommand`][unrunnable] when the end of the program
+    /// cannot be waited for, and [`UnreportableOutput`][unreportable] when the
+    /// end of the run cannot be reported.
+    ///
+    /// [cancelled]: RunProcessError::CancelledRun
+    /// [unreportable]: RunProcessError::UnreportableOutput
+    /// [unrunnable]: RunProcessError::UnrunnableCommand
+    // r[impl process.run.cancel]
+    async fn complete(
+        &self,
+        id: RunId,
+        invocation: Invocation,
+        mut run: Run,
+        started: Instant,
+    ) -> Result<Execution, RunProcessError> {
+        let ended = tokio::select! {
+            biased;
+
+            () = self.cancellation.cancelled() => None,
+            ended = run.wait_for_end() => Some(ended),
+        };
+
+        let Some(ended) = ended else {
+            return Err(self.cancel(id, invocation, run, started).await);
+        };
+
+        let waited = match ended {
+            Ok(()) => run.wait().await,
+            Err(source) => {
+                drop(run.stop(self.grace_period).await);
+
+                Err(source)
+            }
+        };
+
+        let execution = match waited {
+            Ok(execution) => execution,
+            Err(source) => {
+                drop(
+                    self.end(id, &invocation, Outcome::Incomplete, started)
+                        .await,
+                );
+
+                return Err(RunProcessError::UnrunnableCommand { source });
+            }
+        };
+
+        let outcome = Outcome::Exited(execution.status());
+
+        self.end(id, &invocation, outcome, started)
+            .await
+            .map_err(|source| RunProcessError::UnreportableOutput { invocation, source })?;
+
+        Ok(execution)
+    }
+
+    /// Reports the end of a run
+    ///
+    /// A caller that already has an error to report drops the result of this
+    /// method. The consumer that would have read the event is the one that is
+    /// gone, so a second failure says nothing that the first one does not.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SendError`] if the consumer of the events has stopped
+    /// listening.
+    // r[impl process.run.lifecycle]
+    async fn end(
+        &self,
+        id: RunId,
+        invocation: &Invocation,
+        outcome: Outcome,
+        started: Instant,
+    ) -> Result<(), SendError> {
+        let event = ProcessEvent::Finished {
+            id,
+            invocation: invocation.clone(),
+            outcome,
+            duration: started.elapsed(),
+        };
+
+        self.output.process_event(event).await
+    }
+
+    /// Sends one event of a run, naming the command if the send fails
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UnreportableOutput`][unreportable] if the consumer of the
+    /// events has stopped listening.
+    ///
+    /// [unreportable]: RunProcessError::UnreportableOutput
+    async fn report(
+        &self,
+        invocation: &Invocation,
+        event: ProcessEvent,
+    ) -> Result<(), RunProcessError> {
+        self.output.process_event(event).await.map_err(|source| {
+            RunProcessError::UnreportableOutput {
+                invocation: invocation.clone(),
+                source,
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // An assertion in a test panics by design. A `# Panics` section on every test
+    // would repeat that and give the reader no information.
+    #![allow(clippy::missing_panics_doc)]
+
+    #[cfg(unix)]
+    use std::fs::read_to_string;
+    use std::time::Duration;
+
+    use kawauso_process::run::Stream;
+    #[cfg(unix)]
+    use tempfile::TempDir;
+    use tokio::time::{sleep, timeout};
+
+    use super::*;
+    use crate::event::{Event, EventReceiver, event_channel};
+
+    /// Returns the events of every run that the channel holds
+    ///
+    /// The channel closes when the test drops the handle that sent the events,
+    /// so the drain reads to the end and needs no timeout of its own.
+    async fn drain(mut receiver: EventReceiver) -> Vec<ProcessEvent> {
+        let mut events = Vec::new();
+
+        while let Some(event) = receiver.recv().await {
+            match event {
+                Event::Process(event) => events.push(*event),
+                Event::Message(_) | Event::Detail(_) | Event::Artifact(_) => {}
+            }
+        }
+
+        events
+    }
+
+    /// Returns whether the error reports a run that cancellation stopped
+    fn is_cancelled(error: &RunProcessError) -> bool {
+        match error {
+            RunProcessError::CancelledRun { .. } => true,
+            RunProcessError::UnrunnableCommand { .. } => false,
+            RunProcessError::UnreportableOutput { .. } => false,
+        }
+    }
+
+    /// Returns every line of output that the events carry, in the order of arrival
+    fn lines(events: &[ProcessEvent]) -> Vec<(Stream, String)> {
+        events
+            .iter()
+            .filter_map(|event| match event {
+                ProcessEvent::Line { line, .. } => {
+                    Some((line.stream(), line.text().get().to_owned()))
+                }
+                ProcessEvent::Started { .. } => None,
+                ProcessEvent::Finished { .. } => None,
+            })
+            .collect()
+    }
+
+    /// Returns the outcome of the run that the events describe
+    fn outcome(events: &[ProcessEvent]) -> Option<Outcome> {
+        events.iter().find_map(|event| match event {
+            ProcessEvent::Finished { outcome, .. } => Some(outcome.clone()),
+            ProcessEvent::Started { .. } => None,
+            ProcessEvent::Line { .. } => None,
+        })
+    }
+
+    /// Returns an invocation that gives the commands to the shell of the platform
+    ///
+    /// A test needs a program that writes what the test expects, and the shell
+    /// is the program that every machine has. The separator between two
+    /// commands differs between the platforms, so the helper joins them for the
+    /// shell that runs them.
+    fn shell(commands: &[&str]) -> Invocation {
+        if cfg!(windows) {
+            Invocation::new("cmd").arg("/C").arg(commands.join(" & "))
+        } else {
+            Invocation::new("sh").arg("-c").arg(commands.join("; "))
+        }
+    }
+
+    // r[verify process.new]
+    // r[verify process.safety.clone]
+    #[tokio::test]
+    async fn clone_reports_through_the_same_channel() {
+        let (sender, receiver) = event_channel();
+        let process = Process::builder().output(Output::new(sender)).build();
+        let clone = process.clone();
+
+        clone.run(shell(&["exit 0"])).await.expect("should run");
+        drop(process);
+        drop(clone);
+
+        assert_eq!(drain(receiver).await.len(), 2);
+    }
+
+    // r[verify process.event.finished]
+    #[tokio::test]
+    async fn run_reports_the_command_and_the_time_of_the_run() {
+        let (sender, receiver) = event_channel();
+        let process = Process::builder().output(Output::new(sender)).build();
+        let invocation = shell(&["exit 0"]);
+
+        process.run(invocation.clone()).await.expect("should run");
+        drop(process);
+
+        assert_eq!(
+            drain(receiver).await.iter().find_map(|event| match event {
+                ProcessEvent::Finished {
+                    invocation,
+                    duration,
+                    ..
+                } => Some((invocation.to_string(), *duration > Duration::ZERO)),
+                ProcessEvent::Started { .. } => None,
+                ProcessEvent::Line { .. } => None,
+            }),
+            Some((invocation.to_string(), true))
+        );
+    }
+
+    // r[verify process.event.lifecycle]
+    // r[verify process.run.lifecycle]
+    #[tokio::test]
+    async fn run_reports_the_lifecycle_of_the_program() {
+        let (sender, receiver) = event_channel();
+        let process = Process::builder().output(Output::new(sender)).build();
+
+        process
+            .run(shell(&["echo only"]))
+            .await
+            .expect("should run");
+        drop(process);
+
+        assert_eq!(
+            drain(receiver)
+                .await
+                .iter()
+                .map(|event| match event {
+                    ProcessEvent::Started { .. } => "started",
+                    ProcessEvent::Line { .. } => "line",
+                    ProcessEvent::Finished { .. } => "finished",
+                })
+                .collect::<Vec<_>>(),
+            vec!["started", "line", "finished"]
+        );
+    }
+
+    // r[verify process.event.line]
+    // r[verify process.run]
+    // r[verify process.run.stream]
+    #[tokio::test]
+    async fn run_reports_the_lines_of_the_program() {
+        let (sender, receiver) = event_channel();
+        let process = Process::builder().output(Output::new(sender)).build();
+
+        process
+            .run(shell(&["echo one", "echo two"]))
+            .await
+            .expect("should run");
+        drop(process);
+
+        assert_eq!(
+            lines(&drain(receiver).await),
+            vec![
+                (Stream::StandardOutput, "one".to_owned()),
+                (Stream::StandardOutput, "two".to_owned()),
+            ]
+        );
+    }
+
+    // r[verify process.event.outcome]
+    // r[verify process.event.outcome.exited]
+    #[tokio::test]
+    async fn run_reports_the_outcome_of_the_program() {
+        let (sender, receiver) = event_channel();
+        let process = Process::builder().output(Output::new(sender)).build();
+
+        let execution = process.run(shell(&["exit 0"])).await.expect("should run");
+        drop(process);
+
+        assert_eq!(
+            outcome(&drain(receiver).await),
+            Some(Outcome::Exited(execution.status()))
+        );
+    }
+
+    // r[verify process.event.started.identifier]
+    #[tokio::test]
+    async fn run_reports_the_identifier_of_the_program() {
+        let (sender, receiver) = event_channel();
+        let process = Process::builder().output(Output::new(sender)).build();
+
+        process.run(shell(&["exit 0"])).await.expect("should run");
+        drop(process);
+
+        assert_eq!(
+            drain(receiver).await.iter().find_map(|event| match event {
+                ProcessEvent::Started { process_id, .. } => Some(process_id.is_some()),
+                ProcessEvent::Line { .. } => None,
+                ProcessEvent::Finished { .. } => None,
+            }),
+            Some(true)
+        );
+    }
+
+    // r[verify process.event.started]
+    #[tokio::test]
+    async fn run_reports_the_start_of_the_program() {
+        let (sender, receiver) = event_channel();
+        let process = Process::builder().output(Output::new(sender)).build();
+        let invocation = shell(&["exit 0"]);
+
+        process.run(invocation.clone()).await.expect("should run");
+        drop(process);
+
+        assert_eq!(
+            drain(receiver).await.first().map(ProcessEvent::to_string),
+            Some(format!("$ {invocation}"))
+        );
+    }
+
+    // r[verify process.run.capture]
+    #[tokio::test]
+    async fn run_returns_the_capture_of_the_program() {
+        let (sender, _receiver) = event_channel();
+        let process = Process::builder().output(Output::new(sender)).build();
+
+        let execution = process
+            .run(shell(&["echo hello"]))
+            .await
+            .expect("should run");
+
+        assert_eq!(execution.stdout().to_string_lossy().trim(), "hello");
+    }
+
+    // r[verify process.event.line]
+    #[tokio::test]
+    async fn run_separates_the_streams_of_the_program() {
+        let (sender, receiver) = event_channel();
+        let process = Process::builder().output(Output::new(sender)).build();
+
+        process
+            .run(shell(&["echo out", "echo err 1>&2"]))
+            .await
+            .expect("should run");
+        drop(process);
+
+        let mut found = lines(&drain(receiver).await);
+        found.sort();
+
+        assert_eq!(
+            found,
+            vec![
+                (Stream::StandardError, "err".to_owned()),
+                (Stream::StandardOutput, "out".to_owned()),
+            ]
+        );
+    }
+
+    // r[verify process.run.cancel.grace]
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_with_a_cancelled_token_lets_the_program_end_itself() {
+        let directory = TempDir::new().expect("should create a directory");
+        let marker = directory.path().join("cleaned");
+        let cancellation = Cancellation::new();
+        let (sender, mut receiver) = event_channel();
+        let process = Process::builder()
+            .output(Output::new(sender))
+            .cancellation(cancellation.clone())
+            .build();
+        let invocation = shell(&[
+            &format!("trap 'touch \"{}\"; exit 0' TERM", marker.display()),
+            "echo ready",
+            "sleep 20 & wait",
+        ]);
+
+        let handle = tokio::spawn(async move { process.run(invocation).await });
+        while let Some(event) = receiver.recv().await {
+            let ready = match event {
+                Event::Process(event) => match *event {
+                    ProcessEvent::Line { .. } => true,
+                    ProcessEvent::Started { .. } => false,
+                    ProcessEvent::Finished { .. } => false,
+                },
+                Event::Message(_) | Event::Detail(_) | Event::Artifact(_) => false,
+            };
+
+            if ready {
+                break;
+            }
+        }
+        cancellation.cancel();
+        timeout(Duration::from_secs(20), handle)
+            .await
+            .expect("should not time out")
+            .expect("should join")
+            .expect_err("should fail");
+
+        assert!(marker.exists());
+    }
+
+    // r[verify process.run.cancel]
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_with_a_cancelled_token_kills_the_program() {
+        let directory = TempDir::new().expect("should create a directory");
+        let beats = directory.path().join("beats");
+        let cancellation = Cancellation::new();
+        let (sender, _receiver) = event_channel();
+        let process = Process::builder()
+            .output(Output::new(sender))
+            .cancellation(cancellation.clone())
+            .build();
+        let invocation = shell(&[&format!(
+            "while true; do echo beat >> '{}'; sleep 0.05; done",
+            beats.display()
+        )]);
+
+        let handle = tokio::spawn(async move { process.run(invocation).await });
+        sleep(Duration::from_millis(300)).await;
+        cancellation.cancel();
+        timeout(Duration::from_secs(30), handle)
+            .await
+            .expect("should not time out")
+            .expect("should join")
+            .expect_err("should fail");
+        let written = read_to_string(&beats).expect("should read the beats");
+        written
+            .lines()
+            .next()
+            .expect("the program should have written a beat");
+        sleep(Duration::from_millis(400)).await;
+
+        assert_eq!(
+            read_to_string(&beats).expect("should read the beats"),
+            written
+        );
+    }
+
+    // r[verify process.event.outcome.cancelled]
+    #[tokio::test]
+    async fn run_with_a_cancelled_token_reports_the_cancellation() {
+        let cancellation = Cancellation::new();
+        let (sender, receiver) = event_channel();
+        let process = Process::builder()
+            .output(Output::new(sender))
+            .cancellation(cancellation.clone())
+            .build();
+        cancellation.cancel();
+
+        process
+            .run(shell(&["sleep 30"]))
+            .await
+            .expect_err("should fail");
+        drop(process);
+
+        assert_eq!(outcome(&drain(receiver).await), Some(Outcome::Cancelled));
+    }
+
+    // r[verify process.run.cancel.error]
+    #[tokio::test]
+    async fn run_with_a_cancelled_token_returns_an_error() {
+        let cancellation = Cancellation::new();
+        let (sender, _receiver) = event_channel();
+        let process = Process::builder()
+            .output(Output::new(sender))
+            .cancellation(cancellation.clone())
+            .build();
+        cancellation.cancel();
+
+        let error = process
+            .run(shell(&["sleep 30"]))
+            .await
+            .expect_err("should fail");
+
+        assert!(is_cancelled(&error));
+    }
+
+    // r[verify process.run.report.error]
+    #[tokio::test]
+    async fn run_with_a_closed_channel_returns_an_error() {
+        let (sender, receiver) = event_channel();
+        let process = Process::builder().output(Output::new(sender)).build();
+        drop(receiver);
+
+        let error = process
+            .run(shell(&["exit 0"]))
+            .await
+            .expect_err("should fail");
+
+        assert!(matches_unreportable_output(&error));
+    }
+
+    // r[verify process.run.error]
+    #[tokio::test]
+    async fn run_with_a_missing_program_returns_an_error() {
+        let (sender, _receiver) = event_channel();
+        let process = Process::builder().output(Output::new(sender)).build();
+
+        let error = process
+            .run(Invocation::new("clawless-no-such-program"))
+            .await
+            .expect_err("should fail");
+
+        assert!(matches_unrunnable_command(&error));
+    }
+
+    // r[verify process.run.cancel.grace]
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_with_a_program_that_closed_its_streams_ends_itself_on_cancellation() {
+        let directory = TempDir::new().expect("should create a directory");
+        let marker = directory.path().join("cleaned");
+        let cancellation = Cancellation::new();
+        let (sender, _receiver) = event_channel();
+        let process = Process::builder()
+            .output(Output::new(sender))
+            .cancellation(cancellation.clone())
+            .build();
+        let invocation = shell(&[
+            &format!("trap 'touch \"{}\"; exit 0' TERM", marker.display()),
+            "exec 1>&- 2>&-",
+            "sleep 20 & wait",
+        ]);
+
+        let handle = tokio::spawn(async move { process.run(invocation).await });
+        sleep(Duration::from_millis(250)).await;
+        cancellation.cancel();
+        timeout(Duration::from_secs(30), handle)
+            .await
+            .expect("should not time out")
+            .expect("should join")
+            .expect_err("should fail");
+
+        assert!(marker.exists());
+    }
+
+    // r[verify process.run.cancel]
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_with_a_program_that_closed_its_streams_stops_on_cancellation() {
+        let cancellation = Cancellation::new();
+        let (sender, _receiver) = event_channel();
+        let process = Process::builder()
+            .output(Output::new(sender))
+            .cancellation(cancellation.clone())
+            .build();
+        let invocation = shell(&["exec 1>&- 2>&-", "sleep 30"]);
+
+        let handle = tokio::spawn(async move { process.run(invocation).await });
+        sleep(Duration::from_millis(250)).await;
+        cancellation.cancel();
+        let error = timeout(Duration::from_secs(30), handle)
+            .await
+            .expect("should not time out")
+            .expect("should join")
+            .expect_err("should fail");
+
+        assert!(is_cancelled(&error));
+    }
+
+    // r[verify process.new.grace]
+    // r[verify process.run.cancel.bound]
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_with_a_program_that_leaves_a_child_returns_within_the_grace_period() {
+        let cancellation = Cancellation::new();
+        let (sender, _receiver) = event_channel();
+        let process = Process::builder()
+            .output(Output::new(sender))
+            .cancellation(cancellation.clone())
+            .grace_period(Duration::from_millis(200))
+            .build();
+        let invocation = shell(&["echo ready", "sleep 20"]);
+
+        let handle = tokio::spawn(async move { process.run(invocation).await });
+        sleep(Duration::from_millis(200)).await;
+        cancellation.cancel();
+        let started = Instant::now();
+        timeout(Duration::from_secs(20), handle)
+            .await
+            .expect("should not time out")
+            .expect("should join")
+            .expect_err("should fail");
+
+        assert!(started.elapsed() < Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn run_with_an_unsuccessful_program_returns_the_status() {
+        let (sender, _receiver) = event_channel();
+        let process = Process::builder().output(Output::new(sender)).build();
+
+        let execution = process.run(shell(&["exit 3"])).await.expect("should run");
+
+        assert_eq!(execution.status().code(), Some(3));
+    }
+
+    // r[verify process.run.cancel]
+    #[tokio::test]
+    async fn run_with_cancellation_while_the_program_runs_returns_an_error() {
+        let cancellation = Cancellation::new();
+        let (sender, mut receiver) = event_channel();
+        let process = Process::builder()
+            .output(Output::new(sender))
+            .cancellation(cancellation.clone())
+            .grace_period(Duration::from_millis(200))
+            .build();
+        let invocation = shell(&["echo ready", "sleep 30"]);
+
+        let handle = tokio::spawn(async move { process.run(invocation).await });
+        while let Some(event) = receiver.recv().await {
+            let ready = match event {
+                Event::Process(event) => match *event {
+                    ProcessEvent::Line { .. } => true,
+                    ProcessEvent::Started { .. } => false,
+                    ProcessEvent::Finished { .. } => false,
+                },
+                Event::Message(_) | Event::Detail(_) | Event::Artifact(_) => false,
+            };
+
+            if ready {
+                break;
+            }
+        }
+        cancellation.cancel();
+        let error = timeout(Duration::from_secs(30), handle)
+            .await
+            .expect("should not time out")
+            .expect("should join")
+            .expect_err("should fail");
+
+        assert!(is_cancelled(&error));
+    }
+
+    // r[verify process.safety.send]
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Process>();
+    }
+
+    // r[verify process.safety.sync]
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Process>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<Process>();
+    }
+
+    /// Returns whether the error reports output that could not be reported
+    fn matches_unreportable_output(error: &RunProcessError) -> bool {
+        match error {
+            RunProcessError::UnreportableOutput { .. } => true,
+            RunProcessError::CancelledRun { .. } => false,
+            RunProcessError::UnrunnableCommand { .. } => false,
+        }
+    }
+
+    /// Returns whether the error reports a program that could not be run
+    fn matches_unrunnable_command(error: &RunProcessError) -> bool {
+        match error {
+            RunProcessError::UnrunnableCommand { .. } => true,
+            RunProcessError::CancelledRun { .. } => false,
+            RunProcessError::UnreportableOutput { .. } => false,
+        }
+    }
+}


### PR DESCRIPTION
This change adds `Context::process()`, the interface a command uses to run another program. A run starts the program, sends every line it writes into the event system as the line arrives, ends the program when the command is cancelled, and returns the exit status together with the whole output. A command therefore gets live output, no deadlock on a full pipe, cooperative shutdown, and an error that names the command, without writing any of it itself.

Cancellation asks the program to end and kills it only if it does not answer within a grace period, so a build tool gets the moment it needs to remove its lock file. The period defaults to five seconds and a caller names its own through the builder. A program that answers costs what answering takes, so the period is paid in full only by one that ignores the request.

Each way a run can fail is a variant of its own, because a command treats them differently: a cancelled command stops, a command whose program never ran reports the program, and a command whose output can no longer be reported has lost its presenter and ends. A program that ran and failed is none of these — its status travels in the result, and `require_success` turns a status the caller cannot accept into an error that names the command, the status, and what the program wrote to its standard error.
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
