### PR TITLE
Show how a command runs an external program

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,9 @@ crates/
   └── clawless-tui/          # TUI presentation layer (pull-based)
 examples/
   ├── cancellation/          # Cooperative cancellation example
-  └── hello-world/           # Reference example project
+  ├── hello-world/           # Reference example project
+  ├── output/                # Messages, details, and artifacts
+  └── process/               # Running external programs
 docs/                        # Docusaurus documentation site
 specs/                       # Design specifications
 ```
@@ -517,6 +519,9 @@ fn helper() {}
 - Name tests descriptively: `function_name_<condition>_<result>`, e.g.
   `greet_with_name_returns_greeting`.
 - Each test should have exactly one assertion.
+- A `// r[verify <rule>]` comment belongs to the test directly below it.
+  Alphabetical ordering means a new test often lands between an existing
+  annotation and its test, so check what sits above the insertion point.
 
 Testing tools:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,6 +776,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "process"
+version = "0.6.1"
+dependencies = [
+ "clawless",
+ "serde",
+ "trycmd",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/docs/docs/concepts/context.md
+++ b/docs/docs/concepts/context.md
@@ -134,6 +134,32 @@ full explanation.
 
 [output-type]: https://docs.rs/clawless/latest/clawless/output/struct.Output.html
 
+### External programs
+
+Run another program and stream its output through the event system:
+
+```rust
+use clawless::prelude::*;
+
+#[command]
+pub async fn build(args: BuildArgs, context: Context) -> CommandResult {
+    context
+        .process()
+        .run(Invocation::new("cargo").arg("build"))
+        .await?
+        .require_success()?;
+
+    Ok(())
+}
+```
+
+The `process()` method returns a [`Process`][process-type] wired to the output
+and the cancellation token of this context. Every line the program writes
+becomes an event while it runs, and Ctrl+C kills the program. See
+[External Programs](./external-programs) for the full explanation.
+
+[process-type]: https://docs.rs/clawless/latest/clawless/process/struct.Process.html
+
 ## Future features
 
 The Context system is designed to be the central access point for all framework
@@ -240,6 +266,8 @@ Now that you understand Context, learn about:
   and JSON support
 - **[Cancellation](./cancellation)** - How cooperative shutdown works through
   the cancellation token
+- **[External Programs](./external-programs)** - Running other programs from
+  your commands
 - **[Commands](./commands)** - How Context integrates with command functions
 - **[Arguments](./arguments)** - The other parameter commands receive
 - **[Project Structure](./project-structure)** - Organizing commands in your

--- a/docs/docs/concepts/external-programs.md
+++ b/docs/docs/concepts/external-programs.md
@@ -1,0 +1,195 @@
+---
+sidebar_position: 6
+---
+
+# External Programs
+
+Most command-line applications drive other programs. Clawless gives your
+commands a first-class way to run them: the output of the program streams
+through the event system while it runs, cancellation kills it, and the result
+carries everything the program wrote.
+
+## What is a process?
+
+A process is one run of an external program. You describe the run with an
+[`Invocation`][invocation] and hand it to the [`Process`][process] interface
+that [`Context`][context] provides:
+
+```rust
+use clawless::prelude::*;
+
+/// Build the project
+#[command]
+pub async fn build(args: BuildArgs, context: Context) -> CommandResult {
+    let execution = context
+        .process()
+        .run(Invocation::new("cargo").arg("build"))
+        .await
+        .context("build the project")?
+        .require_success()
+        .context("check what cargo reported")?;
+
+    message!("cargo wrote {} bytes", execution.stdout().get().len());
+
+    Ok(())
+}
+```
+
+No shell reads the command. Nothing splits an argument at a space, removes a
+quotation mark, or expands a character such as `*`, so an argument that holds a
+space stays one argument. If you want a shell, name the shell as the program.
+
+## Live output
+
+Clawless sends every line the program writes into the event system as the line
+arrives. Your command writes no code for this — running the program is enough:
+
+```console
+$ mycli --verbose build
+$ cargo build
+   Compiling mycli v0.1.0
+    Finished `dev` profile in 3.21s
+cargo build exited with code 0
+```
+
+Every event carries the `RunId` of its run, which is what separates two programs
+your command runs at the same time, and the start of a run also carries the
+`ProcessId` the operating system gave the program.
+
+Because the lines are events, the [presenter][rendering] decides what to do
+with them. A stateless CLI prints them as they arrive. A TUI keeps them in a
+[projection][rendering] and shows the last few in a corner of the screen:
+
+```rust
+let tail: Vec<_> = projection
+    .processes()
+    .into_iter()
+    .rev()
+    .take(5)
+    .collect();
+```
+
+The output of a program is supplementary, so it appears at `--verbose` and not
+at the default verbosity. Your command decides what the user sees by default:
+say `message!("building")` and the user gets one line instead of a wall of
+compiler output.
+
+In text mode, what the program wrote to its standard error goes to the standard
+error of your application. Redirecting one of the two streams therefore gives
+the same split that running the program by hand would give.
+
+## Reading the result
+
+The same output that streamed as events also reaches your command in the
+[`Execution`][execution]:
+
+```rust
+let execution = context.process().run(invocation).await?;
+
+let text = execution.stdout().to_string_lossy();
+let took = execution.duration();
+let code = execution.status().code();
+let pid = execution.id();
+```
+
+You do not have to choose between showing the output and using it.
+
+## Exit status is data
+
+A program that exits with a non-zero code is not a failure of the run. The
+check mode of a formatter exits non-zero when it finds a file to format, and
+that is the answer you asked for. The status travels in the `Execution`, and
+you decide what it means:
+
+```rust
+let execution = context.process().run(invocation).await?;
+
+if execution.status().success() {
+    message!("everything is formatted");
+} else {
+    message!("some files need formatting");
+}
+```
+
+When your command cannot accept a failure, `require_success` turns the status
+into an error that names the command, the status, and what the program wrote to
+its standard error:
+
+```console
+Error: check what the program reported
+
+Caused by:
+    the command `false` ended with exit status: 1, and it wrote nothing to its standard error
+```
+
+## Cancellation ends the program
+
+A run observes the [cancellation][cancellation] token of your command. When the
+user presses Ctrl+C, Clawless ends the program and the run returns
+`RunProcessError::CancelledRun`. You do not leave a build running behind you,
+and you write no code to achieve that.
+
+The program is asked to end first and killed only if it does not answer, so a
+build tool gets the moment it needs to remove its lock file. That moment is the
+grace period, five seconds by default. Build your own handle when a program needs
+longer:
+
+```rust
+let process = Process::builder()
+    .output(context.output().clone())
+    .cancellation(context.cancellation().clone())
+    .grace_period(Duration::from_secs(30))
+    .build();
+```
+
+The grace period is a ceiling, not a cost. A program that answers the request
+costs only what answering takes, so the period is paid in full only by a program
+that ignores it.
+
+Cancellation works both while the program is writing output and after it has
+stopped writing, so a program that closes its streams and keeps running is asked
+to end like any other.
+
+## Errors
+
+`Process::run` fails in three ways, and each is a variant of its own so you can
+treat them differently:
+
+| Variant              | Meaning                                               |
+| -------------------- | ----------------------------------------------------- |
+| `UnrunnableCommand`  | The program never started, or the run had no result   |
+| `CancelledRun`       | Cancellation stopped the program                      |
+| `UnreportableOutput` | The presenter stopped listening while the program ran |
+
+A command that treats cancellation as an orderly end matches `CancelledRun` and
+returns `Ok(())`.
+
+## Why it works this way
+
+**Pipes never fill.** A program that writes more than a pipe holds stops until
+a reader empties it. Clawless reads both streams while it waits, so a talkative
+program cannot deadlock your command.
+
+**Output arrives on time.** A command that collects output and prints it
+afterwards shows nothing for two minutes and then everything at once. Streaming
+the lines as events means the user sees progress.
+
+**The command does not know the renderer.** The same command code streams to a
+terminal, into a TUI panel, or into a test harness. That is the same property
+`message!` and `artifact!` have, extended to the programs your command runs.
+
+**Standard input is null.** A program that asks for a password sees the end of
+its input at once and ends, instead of hanging while nobody types an answer.
+
+## What's next
+
+- **[Rendering](./rendering)** - How events reach the terminal or a TUI
+- **[Cancellation](./cancellation)** - The token that stops a run
+- **[Output](./output)** - The other kinds of output a command produces
+
+[cancellation]: ./cancellation
+[context]: ./context
+[execution]: https://docs.rs/clawless/latest/clawless/process/struct.Execution.html
+[invocation]: https://docs.rs/clawless/latest/clawless/process/struct.Invocation.html
+[process]: https://docs.rs/clawless/latest/clawless/process/struct.Process.html
+[rendering]: ./rendering

--- a/docs/docs/concepts/index.md
+++ b/docs/docs/concepts/index.md
@@ -46,6 +46,12 @@ Cooperative shutdown through cancellation tokens. Learn how Clawless handles
 Ctrl+C signals, how commands observe cancellation to shut down gracefully, and
 how parent-child tokens enable scoped cancellation.
 
+### [External Programs](./external-programs)
+
+Running other programs from your commands. Learn how Clawless streams the
+output of a program through the event system while it runs, how cancellation
+kills it, and how to read what it produced afterwards.
+
 ### [Macros](./macros)
 
 Clawless uses four macros to wire up your CLI. Understand how `main!`,
@@ -104,10 +110,12 @@ If you're new to Clawless:
 4. Read **[Rendering](./rendering)** to understand how output reaches the
    terminal
 5. Read **[Cancellation](./cancellation)** to understand cooperative shutdown
-6. Explore **[Project Structure](./project-structure)** to understand how to
+6. Read **[External Programs](./external-programs)** when your CLI needs to run
+   other programs
+7. Explore **[Project Structure](./project-structure)** to understand how to
    organize your CLI
-7. Read **[Macros](./macros)** if you're curious about implementation details
-8. Reference **[Naming Conventions](./naming-conventions)** when you need to
+8. Read **[Macros](./macros)** if you're curious about implementation details
+9. Reference **[Naming Conventions](./naming-conventions)** when you need to
    look up specific rules
 
 For experienced developers, the **[Macros](./macros)** section provides insight

--- a/docs/docs/concepts/macros.md
+++ b/docs/docs/concepts/macros.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Macros

--- a/docs/docs/concepts/naming-conventions.md
+++ b/docs/docs/concepts/naming-conventions.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Naming Conventions

--- a/docs/docs/concepts/project-structure.md
+++ b/docs/docs/concepts/project-structure.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Project Structure

--- a/examples/process/Cargo.toml
+++ b/examples/process/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "process"
+description = "Demonstrates running external programs in clawless"
+
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+# We do not want to publish examples to crates.io, since they provide no value
+# or functionality on their own.
+publish = false
+
+[dependencies]
+clawless = { workspace = true }
+serde = { workspace = true }
+
+[dev-dependencies]
+trycmd = { workspace = true }
+
+[lints]
+workspace = true

--- a/examples/process/src/commands/mod.rs
+++ b/examples/process/src/commands/mod.rs
@@ -1,0 +1,4 @@
+/// Runs another program and reports what it produced
+mod run;
+
+clawless::commands!();

--- a/examples/process/src/commands/run.rs
+++ b/examples/process/src/commands/run.rs
@@ -1,0 +1,79 @@
+use std::fmt;
+use std::path::PathBuf;
+
+use clawless::prelude::*;
+
+/// Arguments for the `run` command
+///
+/// Takes the program to run and the arguments to pass to it. No shell reads the command, so an
+/// argument that holds a space stays one argument and nothing expands a character such as `*`.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Args)]
+pub struct RunArgs {
+    /// Program to run
+    program: PathBuf,
+
+    /// Arguments to pass to the program
+    #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
+    arguments: Vec<String>,
+}
+
+/// How much the program wrote to each of its streams
+///
+/// In text mode this displays as a sentence. In JSON mode it serializes as an object, which is
+/// how a command reports a measurement that another tool reads.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize)]
+struct Captured {
+    /// Bytes that the program wrote to its standard output
+    stdout: usize,
+
+    /// Bytes that the program wrote to its standard error
+    stderr: usize,
+}
+
+impl fmt::Display for Captured {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} bytes on standard output, {} bytes on standard error",
+            self.stdout, self.stderr
+        )
+    }
+}
+
+/// Run another program and report what it produced
+///
+/// Clawless sends every line that the program writes into the event system as the line arrives,
+/// so `--verbose` shows a long-running program while it runs instead of after it ended. The same
+/// output also reaches the command in the result, which is what this command measures.
+///
+/// Press Ctrl+C while the program runs to see cooperative shutdown kill it.
+///
+/// ```shell
+/// process --verbose run echo hello
+/// ```
+#[command]
+// A command's doc comment is its `--help` text, so an `# Errors` section would render as a
+// raw Markdown heading in the terminal rather than documenting an API.
+#[allow(clippy::missing_errors_doc)]
+pub async fn run(args: RunArgs, context: Context) -> CommandResult {
+    let RunArgs { program, arguments } = args;
+
+    let invocation = Invocation::new(program).args(arguments);
+
+    message!("running {invocation}");
+
+    let execution = context
+        .process()
+        .run(invocation)
+        .await
+        .context("run the program")?
+        .require_success()
+        .context("check what the program reported")?;
+
+    artifact!(Captured {
+        stdout: execution.stdout().get().len(),
+        stderr: execution.stderr().get().len(),
+    });
+
+    Ok(())
+}

--- a/examples/process/src/main.rs
+++ b/examples/process/src/main.rs
@@ -1,0 +1,15 @@
+//! External program example
+//!
+//! This example shows how a command runs another program, reports its output while it runs,
+//! and reads what the program produced after it ended. Pass `--verbose` to see the output of
+//! the program itself, which Clawless streams through the event system as it arrives.
+
+// This crate compiles to a binary, so nothing in it is reachable from outside the crate
+// and `unreachable_pub` would demand `pub(crate)` on every item. The lint earns its keep
+// in the library crates, where the public API is a real boundary.
+#![allow(unreachable_pub)]
+
+/// The commands of this example
+mod commands;
+
+clawless::main!();

--- a/examples/process/tests/process.rs
+++ b/examples/process/tests/process.rs
@@ -1,0 +1,16 @@
+//! Integration tests for the external program example
+//!
+//! Each `.toml` case in `tests/process/` runs the example against a program that every Unix
+//! machine has. The cases cover what the command reports at each verbosity, in each output
+//! mode, and when the program fails or does not exist at all.
+
+// An assertion in a test panics by design. A `# Panics` section on every test
+// would repeat that and give the reader no information.
+#![allow(clippy::missing_panics_doc)]
+
+// r[verify process.render.verbosity]
+// r[verify process.render.streams]
+#[test]
+fn process() {
+    trycmd::TestCases::new().case("tests/process/*.toml");
+}

--- a/examples/process/tests/process/run-default.toml
+++ b/examples/process/tests/process/run-default.toml
@@ -1,0 +1,7 @@
+bin.name = "process"
+args = ["run", "echo", "hello"]
+status.code = 0
+stdout = """
+running echo hello
+6 bytes on standard output, 0 bytes on standard error
+"""

--- a/examples/process/tests/process/run-json.toml
+++ b/examples/process/tests/process/run-json.toml
@@ -1,0 +1,9 @@
+bin.name = "process"
+args = ["--json", "run", "echo", "hello"]
+status.code = 0
+stdout = """
+{"stdout":6,"stderr":0}
+"""
+stderr = """
+running echo hello
+"""

--- a/examples/process/tests/process/run-missing-program.toml
+++ b/examples/process/tests/process/run-missing-program.toml
@@ -1,0 +1,13 @@
+bin.name = "process"
+args = ["run", "clawless-no-such-program"]
+status.code = 1
+stdout = """
+running clawless-no-such-program
+"""
+stderr = """
+Error: run the program
+
+Caused by:
+    0: failed to start the command `clawless-no-such-program`
+    1: [..]
+"""

--- a/examples/process/tests/process/run-quiet.toml
+++ b/examples/process/tests/process/run-quiet.toml
@@ -1,0 +1,6 @@
+bin.name = "process"
+args = ["--quiet", "run", "echo", "hello"]
+status.code = 0
+stdout = """
+6 bytes on standard output, 0 bytes on standard error
+"""

--- a/examples/process/tests/process/run-unsuccessful.toml
+++ b/examples/process/tests/process/run-unsuccessful.toml
@@ -1,0 +1,12 @@
+bin.name = "process"
+args = ["run", "false"]
+status.code = 1
+stdout = """
+running false
+"""
+stderr = """
+Error: check what the program reported
+
+Caused by:
+    the command `false` ended with [..], and it wrote nothing to its standard error
+"""

--- a/examples/process/tests/process/run-verbose-diagnostics.toml
+++ b/examples/process/tests/process/run-verbose-diagnostics.toml
@@ -1,0 +1,13 @@
+bin.name = "process"
+args = ["--verbose", "run", "sh", "-c", "echo out; echo err 1>&2"]
+status.code = 0
+stdout = """
+running sh -c "echo out; echo err 1>&2"
+$ sh -c "echo out; echo err 1>&2"
+out
+sh -c "echo out; echo err 1>&2" exited with code 0
+4 bytes on standard output, 4 bytes on standard error
+"""
+stderr = """
+err
+"""

--- a/examples/process/tests/process/run-verbose.toml
+++ b/examples/process/tests/process/run-verbose.toml
@@ -1,0 +1,10 @@
+bin.name = "process"
+args = ["--verbose", "run", "echo", "hello"]
+status.code = 0
+stdout = """
+running echo hello
+$ echo hello
+hello
+echo hello exited with code 0
+6 bytes on standard output, 0 bytes on standard error
+"""


### PR DESCRIPTION
The interface for running external programs has no example and no page in the documentation, so this change adds both.

The example runs a program that the user names and reports how much it wrote to each of its streams, which shows the two halves of the interface together: the output streams through the event system as the program writes it, and the same output reaches the command afterwards in the result. Its cases cover each verbosity, both output modes, a program that does not exist, and one that fails, so the behavior a reader is told about is the behavior the tests pin.

The concepts page explains what a reader cannot infer from the API alone: why exit status is data rather than failure, why the grace period is a ceiling and not a cost, and why the output of a program is supplementary and appears only at `--verbose`.
---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
