### PR TITLE
Let a TUI application close on a complete frame

### DIFF
--- a/crates/clawless-derive/src/lib.rs
+++ b/crates/clawless-derive/src/lib.rs
@@ -296,6 +296,17 @@ pub fn command(attrs: TokenStream, input: TokenStream) -> TokenStream {
 /// 2. A `context` parameter: the `Context` for emitting events and cooperative shutdown
 /// 3. A `projection` parameter: the `Projection` for querying accumulated state
 ///
+/// # Projection Visibility
+///
+/// A projection trails the events that an application emits. Emitting puts an event in the
+/// channel and returns; the projection picks it up afterwards, so a query that follows an emit
+/// straight away does not yet show it. A render loop absorbs the lag, because the next frame
+/// shows what the previous frame missed.
+///
+/// The closing frame has no next frame. An application that wants its last events on screen drops
+/// its `Context` to close the channel, awaits `Projection::wait_until_complete`, and renders once
+/// more. See the documentation of `Projection` for the whole picture.
+///
 /// # Attributes
 ///
 /// - `alias = "name"` - Add a visible alias for the application. Can be repeated.

--- a/crates/clawless-tui/src/projection/mod.rs
+++ b/crates/clawless-tui/src/projection/mod.rs
@@ -10,6 +10,11 @@
 //! state. The read lock is held only while cloning the snapshot, keeping contention with the
 //! drain task's write lock brief.
 //!
+//! A projection is eventually consistent with the event channel. Sending an event puts it in the
+//! channel; a separate task then folds it into the projection. A query that runs between those two
+//! moments does not show the event. See [`Projection`] for what this means for a render loop and
+//! for the last frame that an application draws.
+//!
 //! # Examples
 //!
 //! ```
@@ -26,10 +31,7 @@
 //!     .expect("should send");
 //! drop(sender);
 //!
-//! // Wait for the drain task, which finishes once the dropped sender closes the channel
-//! while !projection.is_complete() {
-//!     tokio::task::yield_now().await;
-//! }
+//! projection.wait_until_complete().await;
 //!
 //! assert_eq!(projection.entries().len(), 1);
 //! # }
@@ -42,6 +44,7 @@
 use std::sync::{Arc, RwLock};
 
 use clawless_core::event::{Event, EventReceiver};
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
 pub use self::entry::Entry;
@@ -66,6 +69,25 @@ mod state;
 /// task and query callers synchronize through a [`RwLock`], allowing concurrent reads from
 /// multiple render frames without blocking on each other.
 ///
+/// # Visibility
+///
+/// A projection is eventually consistent with the event channel. Emitting an event puts it in the
+/// channel and returns; the drain task folds it into the projection afterwards. A query that runs
+/// in between therefore does not show the event, and awaiting the send does not change that. An
+/// application that emits an event and queries immediately should expect the entry on a later
+/// frame, not on the current one.
+///
+/// A render loop absorbs this, because the next frame shows what the previous frame missed. The
+/// last frame has no next frame, so an application that wants its closing state on screen drops
+/// its [`Context`] to close the channel, awaits [`wait_until_complete`], and draws once more:
+///
+/// ```rust,ignore
+/// message!("shutting down");
+/// drop(context);
+/// projection.wait_until_complete().await;
+/// render(&projection.entries());
+/// ```
+///
 /// # Examples
 ///
 /// ```
@@ -82,18 +104,17 @@ mod state;
 ///     .expect("should send");
 /// drop(sender);
 ///
-/// // Wait for the drain task, which finishes once the dropped sender closes the channel
-/// while !projection.is_complete() {
-///     tokio::task::yield_now().await;
-/// }
+/// projection.wait_until_complete().await;
 ///
 /// let messages = projection.messages();
 /// assert_eq!(messages.len(), 1);
 /// # }
 /// ```
 ///
+/// [`Context`]: clawless_core::context::Context
 /// [`EventReceiver`]: clawless_core::event::EventReceiver
 /// [`RwLock`]: std::sync::RwLock
+/// [`wait_until_complete`]: Projection::wait_until_complete
 // r[impl projection.new]
 // r[impl projection.new.drain]
 // r[impl projection.safety.send]
@@ -103,8 +124,13 @@ mod state;
 pub struct Projection {
     /// The entries so far, which the projection shares with the drain task
     state: Arc<RwLock<ProjectionState>>,
-    /// Handle to the drain task, which stops when Clawless drops the projection
-    _drain_handle: JoinHandle<()>,
+    /// Carries the completion of the drain, so that a waiter does not poll for it
+    completion: watch::Receiver<bool>,
+    /// Handle to the drain task, which the runner takes so that it can await the drain
+    ///
+    /// Dropping a [`JoinHandle`] detaches its task rather than stopping it, so the drain outlives
+    /// the projection and ends when the event channel closes or the runtime shuts down.
+    drain: Option<JoinHandle<()>>,
 }
 
 impl Projection {
@@ -138,13 +164,25 @@ impl Projection {
     pub fn new(receiver: EventReceiver) -> Self {
         let state = Arc::new(RwLock::new(ProjectionState::default()));
         let drain_state = Arc::clone(&state);
+        let (completed, completion) = watch::channel(false);
 
-        let handle = tokio::spawn(drain(receiver, drain_state));
+        let handle = tokio::spawn(drain(receiver, drain_state, completed));
 
         Self {
             state,
-            _drain_handle: handle,
+            completion,
+            drain: Some(handle),
         }
+    }
+
+    /// Takes the handle of the drain task out of the projection
+    ///
+    /// The runner calls this before it moves the projection into the application, so that it
+    /// still has something to await once the application returns. The drain task itself is
+    /// unaffected: it keeps running, because dropping a [`JoinHandle`] detaches a task instead of
+    /// stopping it. A second call returns [`None`].
+    pub(crate) fn take_drain(&mut self) -> Option<JoinHandle<()>> {
+        self.drain.take()
     }
 
     /// Returns all accumulated entries in receive order
@@ -244,21 +282,85 @@ impl Projection {
     pub fn is_complete(&self) -> bool {
         self.state.read().expect("lock poisoned").is_complete()
     }
+
+    /// Waits until the event stream has closed and every buffered event has been drained
+    ///
+    /// Returns as soon as [`is_complete`] would report `true`, and returns straight away if that
+    /// is already the case. An application awaits this before it draws its closing frame, so that
+    /// the frame shows the events it emitted last. Because completion needs the channel to close,
+    /// the application drops its [`Context`] first; otherwise its own [`EventSender`] holds the
+    /// channel open and this never returns.
+    ///
+    /// This is not a way to read back a single event during a run. It reports the end of the
+    /// stream, not the arrival of one entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use clawless_core::event::{Event, event_channel};
+    /// use clawless_tui::projection::Projection;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let (sender, receiver) = event_channel();
+    /// let projection = Projection::new(receiver);
+    ///
+    /// sender.send(Event::Message("last word".to_string()))
+    ///     .await
+    ///     .expect("should send");
+    /// drop(sender);
+    ///
+    /// projection.wait_until_complete().await;
+    ///
+    /// assert_eq!(projection.entries().len(), 1);
+    /// # }
+    /// ```
+    ///
+    /// [`Context`]: clawless_core::context::Context
+    /// [`EventSender`]: clawless_core::event::EventSender
+    /// [`is_complete`]: Projection::is_complete
+    // r[impl projection.lifecycle.wait]
+    pub async fn wait_until_complete(&self) {
+        let mut completion = self.completion.clone();
+
+        loop {
+            let complete = *completion.borrow_and_update();
+            if complete {
+                return;
+            }
+
+            // A failure here means the sender is gone. The sender lives in the drain task and the
+            // drain announces completion before it ends, so its absence without an announcement
+            // takes a panic. Waiting for word that can no longer come would never return.
+            if completion.changed().await.is_err() {
+                return;
+            }
+        }
+    }
 }
 
 /// Drains events from the receiver into the shared state
 ///
 /// Runs until `receiver.recv()` returns `None` (all senders dropped, channel empty). Each event
 /// is translated into an [`Entry`] and appended to the state. When the loop exits, the state is
-/// marked as complete.
+/// marked as complete and `completed` announces it to any waiter.
+///
+/// The state is marked before the announcement, and never the other way round. A waiter that the
+/// announcement wakes therefore finds every entry already in place, rather than a projection that
+/// calls itself complete while the last entry is still missing.
 ///
 /// # Panics
 ///
 /// Panics if the internal lock is poisoned.
 // The lock is poisoned only if another thread panicked while holding it. The drain task has
 // no way to publish events into a state it cannot lock, so it fails loudly instead.
+// r[impl projection.lifecycle.order]
 #[allow(clippy::expect_used)]
-async fn drain(mut receiver: EventReceiver, state: Arc<RwLock<ProjectionState>>) {
+async fn drain(
+    mut receiver: EventReceiver,
+    state: Arc<RwLock<ProjectionState>>,
+    completed: watch::Sender<bool>,
+) {
     while let Some(event) = receiver.recv().await {
         let entry = match event {
             Event::Message(text) => Entry::Message(text),
@@ -269,6 +371,11 @@ async fn drain(mut receiver: EventReceiver, state: Arc<RwLock<ProjectionState>>)
         state.write().expect("lock poisoned").push(entry);
     }
     state.write().expect("lock poisoned").set_complete();
+
+    // `send_replace` rather than `send`, because a drain that ends after its projection was
+    // dropped has no receiver left and `send` would call that an error. There is nothing to
+    // recover: the announcement has no audience, and the previous value is of no interest.
+    completed.send_replace(true);
 }
 
 #[cfg(test)]
@@ -314,7 +421,7 @@ mod tests {
             .await
             .expect("should send");
         drop(sender);
-        tokio::task::yield_now().await;
+        projection.wait_until_complete().await;
 
         let artifacts = projection.artifacts();
 
@@ -344,7 +451,7 @@ mod tests {
             .await
             .expect("should send");
         drop(sender);
-        tokio::task::yield_now().await;
+        projection.wait_until_complete().await;
 
         let details = projection.details();
 
@@ -370,7 +477,7 @@ mod tests {
         drop(sender);
 
         let projection = Projection::new(receiver);
-        tokio::task::yield_now().await;
+        projection.wait_until_complete().await;
 
         assert!(projection.is_complete());
         let entries = projection.entries();
@@ -394,7 +501,7 @@ mod tests {
             .await
             .expect("should send");
         drop(sender);
-        tokio::task::yield_now().await;
+        projection.wait_until_complete().await;
 
         let entries = projection.entries();
 
@@ -416,7 +523,7 @@ mod tests {
             .await
             .expect("should send");
         drop(sender);
-        tokio::task::yield_now().await;
+        projection.wait_until_complete().await;
 
         let entries = projection.entries();
 
@@ -439,7 +546,7 @@ mod tests {
             .await
             .expect("should send");
         drop(sender);
-        tokio::task::yield_now().await;
+        projection.wait_until_complete().await;
 
         let entries = projection.entries();
 
@@ -469,7 +576,7 @@ mod tests {
             .await
             .expect("should send");
         drop(sender);
-        tokio::task::yield_now().await;
+        projection.wait_until_complete().await;
 
         let entries = projection.entries();
 
@@ -517,7 +624,7 @@ mod tests {
             .await
             .expect("should send");
         drop(sender);
-        tokio::task::yield_now().await;
+        projection.wait_until_complete().await;
 
         let messages = projection.messages();
 
@@ -551,7 +658,7 @@ mod tests {
         let projection = Projection::new(receiver);
 
         drop(sender);
-        tokio::task::yield_now().await;
+        projection.wait_until_complete().await;
 
         assert!(projection.is_complete());
     }
@@ -574,7 +681,7 @@ mod tests {
             .await
             .expect("should send");
         drop(sender);
-        tokio::task::yield_now().await;
+        projection.wait_until_complete().await;
 
         let processes = projection.processes();
 
@@ -582,6 +689,17 @@ mod tests {
             processes.iter().map(Entry::to_string).collect::<Vec<_>>(),
             vec!["compiling".to_string()]
         );
+    }
+
+    #[tokio::test]
+    async fn take_drain_with_a_second_call_returns_none() {
+        let (_sender, receiver) = event_channel();
+        let mut projection = Projection::new(receiver);
+        drop(projection.take_drain());
+
+        let handle = projection.take_drain();
+
+        assert!(handle.is_none());
     }
 
     // r[verify projection.safety.send]
@@ -603,5 +721,74 @@ mod tests {
     fn trait_unpin() {
         fn assert_unpin<T: Unpin>() {}
         assert_unpin::<Projection>();
+    }
+
+    // r[verify projection.lifecycle.wait]
+    #[tokio::test]
+    async fn wait_until_complete_after_the_drain_finished_returns_immediately() {
+        let (sender, receiver) = event_channel();
+        let projection = Projection::new(receiver);
+        drop(sender);
+        projection.wait_until_complete().await;
+
+        projection.wait_until_complete().await;
+
+        assert!(projection.is_complete());
+    }
+
+    // The announcement of completion is what wakes the waiter, so this is where an announcement
+    // that ran ahead of the state would show: the waiter would return and find a projection that
+    // still calls itself incomplete. The multi-threaded flavor is what gives the check teeth,
+    // because the drain runs on another worker and the two writes can be observed apart. A
+    // current-thread runtime hides the difference.
+    // r[verify projection.lifecycle.order]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn wait_until_complete_reports_completion_when_it_returns() {
+        let mut torn = 0;
+
+        for _ in 0..1000 {
+            let (sender, receiver) = event_channel();
+            let projection = Projection::new(receiver);
+            sender
+                .send(Event::Message("last word".to_string()))
+                .await
+                .expect("should send");
+            drop(sender);
+
+            projection.wait_until_complete().await;
+
+            if !projection.is_complete() {
+                torn += 1;
+            }
+        }
+
+        assert_eq!(torn, 0);
+    }
+
+    // Awaiting the send only puts an event in the channel, so a projection read straight after it
+    // is almost always still empty. This is the await that closes that gap, and the count is what
+    // a closing frame depends on.
+    // r[verify projection.lifecycle.wait]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn wait_until_complete_shows_the_event_that_preceded_it() {
+        let mut incomplete = 0;
+
+        for _ in 0..1000 {
+            let (sender, receiver) = event_channel();
+            let projection = Projection::new(receiver);
+            sender
+                .send(Event::Message("last word".to_string()))
+                .await
+                .expect("should send");
+            drop(sender);
+
+            projection.wait_until_complete().await;
+
+            if projection.entries().len() != 1 {
+                incomplete += 1;
+            }
+        }
+
+        assert_eq!(incomplete, 0);
     }
 }

--- a/crates/clawless-tui/src/runner.rs
+++ b/crates/clawless-tui/src/runner.rs
@@ -1,9 +1,9 @@
 //! TUI application runner
 //!
 //! This module defines [`ApplicationRunner`], which encapsulates the full lifecycle of a TUI
-//! application: event channel creation, context construction, projection setup, signal handling, and
-//! application execution. The `main!()` macro dispatches to `ApplicationRunner::run` when the
-//! resolved leaf is an application.
+//! application: event channel creation, context construction, projection setup, signal handling,
+//! application execution, and the drain of the events that the application emitted. The `main!()`
+//! macro dispatches to `ApplicationRunner::run` when the resolved leaf is an application.
 //!
 //! Application authors do not interact with this module directly. The `main!()` macro calls
 //! [`ApplicationRunner::run`] with the resolved matches and the leaf's exec function. The runner
@@ -53,9 +53,20 @@ impl ApplicationRunner {
     /// 3. Creates a Tokio runtime
     /// 4. Inside the runtime, creates a [`Projection`] (which spawns a background drain task)
     /// 5. Spawns the signal handler and calls the application function
+    /// 6. Awaits the drain task once the application returns
     ///
     /// The [`Projection`] must be created inside the Tokio runtime because its constructor calls
     /// `tokio::spawn` to start the background event drain.
+    ///
+    /// Step 6 keeps shutdown whole. Dropping the runtime stops the drain wherever it happens to
+    /// be, so a runner that returned the moment the application did would leave the events of the
+    /// final moments unread. Awaiting the drain instead means the projection accounts for every
+    /// event that the application emitted.
+    ///
+    /// The drain ends because the application's [`Context`] carries the only [`EventSender`], and
+    /// returning drops it. An application that gives a clone of its [`Output`] to a task that it
+    /// never awaits holds the channel open, and this runner then waits for a drain that cannot
+    /// end. `CommandRunner` expects the same of a command.
     ///
     /// # Arguments
     ///
@@ -74,8 +85,11 @@ impl ApplicationRunner {
     /// [`ArgMatches`]: clap::ArgMatches
     /// [`Cancellation`]: clawless_core::cancellation::Cancellation
     /// [`Context`]: clawless_core::context::Context
+    /// [`EventSender`]: clawless_core::event::EventSender
+    /// [`Output`]: clawless_core::output::Output
     /// [`Projection`]: crate::projection::Projection
     // r[impl dispatch.exec.callable]
+    // r[impl dispatch.exec.application-drain]
     pub fn run<E, F>(matches: clap::ArgMatches, exec: E) -> Result<(), Box<dyn std::error::Error>>
     where
         E: FnOnce(clap::ArgMatches, Context, Projection) -> F,
@@ -92,10 +106,26 @@ impl ApplicationRunner {
 
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
-            let projection = Projection::new(receiver);
+            let mut projection = Projection::new(receiver);
+            let drain = projection.take_drain();
 
             tokio::spawn(wait_for_shutdown(cancellation));
-            exec(matches, context, projection).await
+
+            // Binding the result ends the statement that owns the application's future, so the
+            // future is dropped here whatever it still holds, and with it the `Context` that
+            // carries the only `EventSender`. That closes the channel, which is what lets the
+            // drain below finish rather than wait for an event that can no longer arrive.
+            let result = exec(matches, context, projection).await;
+
+            if let Some(drain) = drain {
+                // A join fails when the task panicked, and the drain panics only on a poisoned
+                // lock, which takes a panic elsewhere to cause. The application's own result is
+                // already in hand, and reporting a consequence in its place would bury the
+                // failure that started it.
+                drop(drain.await);
+            }
+
+            result
         })?;
 
         Ok(())
@@ -109,9 +139,41 @@ mod tests {
     #![allow(clippy::missing_panics_doc)]
 
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     use super::*;
+
+    // The count travels out through an atomic because the runner owns the projection and moves it
+    // into the application, which leaves a caller nothing to read afterwards. The application is
+    // also the only place worth asserting from: a closing frame is drawn before the application
+    // returns, so that is where completeness has to hold.
+    //
+    // Three hundred events overrun the 256-slot channel, so the run also covers a drain that has
+    // to keep pace with a producer the channel is holding back.
+    #[test]
+    fn run_lets_an_application_read_a_complete_final_frame() {
+        let matches = clap::Command::new("test").get_matches_from(["test"]);
+        let counted = Arc::new(AtomicUsize::new(0));
+        let owned = Arc::clone(&counted);
+
+        ApplicationRunner::run(matches, move |_matches, context, projection| async move {
+            for index in 0..300 {
+                context
+                    .output()
+                    .message(format!("event {index}"))
+                    .await
+                    .expect("the projection holds the channel open");
+            }
+            drop(context);
+            projection.wait_until_complete().await;
+
+            owned.store(projection.entries().len(), Ordering::SeqCst);
+            Ok(())
+        })
+        .expect("the runner runs the leaf to completion");
+
+        assert_eq!(counted.load(Ordering::SeqCst), 300);
+    }
 
     // r[verify dispatch.exec.callable]
     #[test]

--- a/specs/dispatch.md
+++ b/specs/dispatch.md
@@ -62,6 +62,12 @@ When the resolved leaf is an application, the execution phase MUST delegate to
 a runner that creates the event channel, context, projection, and async
 runtime.
 
+r[dispatch.exec.application-drain]
+After the application returns, the runner MUST await the drain of the
+projection before it drops the async runtime. Dropping the runtime stops the
+drain wherever it stands, which would leave the events of the final moments
+out of the projection.
+
 ## Thread safety
 
 A resolved leaf is passed from the synchronous resolution phase to the

--- a/specs/projection.md
+++ b/specs/projection.md
@@ -60,11 +60,32 @@ r[projection.query.processes]
 A projection MUST provide filtered access to the entries of external programs
 only, so that a view can show the last lines that a program wrote.
 
+## Visibility
+
+A projection is eventually consistent with the event channel. Emitting an event
+puts it in the channel and returns; the drain folds it into the projection
+afterwards. A query between those two moments does not show the event, and
+awaiting the send does not change that.
+
+A render loop absorbs the lag, because the next frame shows what the previous
+frame missed. The last frame has no next frame, so an application that wants
+its closing state on screen needs a way to wait for the drain.
+
 ## Lifecycle
 
 r[projection.lifecycle.complete]
 A projection MUST report whether the event stream has closed and all buffered
 events have been drained.
+
+r[projection.lifecycle.wait]
+A projection MUST provide an await that returns once the event stream has
+closed and all buffered events have been drained, and MUST return immediately
+when that is already the case. A caller MUST NOT need to poll for it.
+
+r[projection.lifecycle.order]
+The drain MUST record the last entry before it reports completion. A caller
+that the report wakes therefore reads a projection that holds every event,
+rather than one that calls itself complete while an entry is still missing.
 
 ## Thread safety
 


### PR DESCRIPTION
A projection trails the event channel it reads. Emitting an event puts it in the channel and returns, and a separate task records it after, so a query that follows an emit almost never shows it: measured over a thousand attempts on a multi-threaded runtime, the entry was missing from 999. A render loop absorbs that, because the next frame shows what the previous frame missed. The closing frame has no next frame, so the last thing an application said was essentially always absent from the last thing it drew. The runner compounded it by dropping the runtime as soon as the application returned, which stopped the drain wherever it stood.

`Projection::wait_until_complete` now waits for the drain rather than leaving a caller to spin on `is_complete`, which no number of yields made reliable. An application drops its `Context` to close the channel, awaits this, and renders a frame that holds every event. The drain records the last entry before it announces completion, so a waiter never wakes to a projection that calls itself complete while an entry is still missing; reversing those two writes fails the new test 473 times in a thousand. The runner also awaits the drain once the application returns, so shutdown no longer tears. Nine tests that stepped one `yield_now` and hoped now await completion instead, which makes them deterministic whichever runtime flavor they run on.

Waiting on the drain has a cost worth naming. An application that hands a clone of its `Output` to a task it never awaits holds the channel open, and the runner then waits for a drain that cannot end. `CommandRunner` has always expected the same of a command, so both runners now fail the same visible way instead of one of them quietly discarding events.